### PR TITLE
Fix TCP Middlewares not being displayed on middlewares tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -3680,6 +3680,10 @@ def _build_middlewares(config, config_file=''):
         buf = StringIO()
         yaml.dump(mdata, buf)
         middlewares.append({'name': mname, 'yaml': buf.getvalue(), 'type': 'http', 'configFile': config_file})
+    for mname, mdata in config.get('tcp', {}).get('middlewares', {}).items():
+        buf = StringIO()
+        yaml.dump(mdata, buf)
+        middlewares.append({'name': mname, 'yaml': buf.getvalue(), 'type': 'tcp', 'configFile': config_file})
     return middlewares
 
 


### PR DESCRIPTION
Fix: app now collects TCP middlewares from the Traefik API – they were missing from the Middlewares tab.

## Summary

The _build_middlewares() function previously only collected HTTP middlewares from the configuration, ignoring TCP middlewares defined under tcp.middlewares. As a result, TCP middlewares were never included in the list passed to the template and thus never appeared on the Middlewares tab.

This PR extends _build_middlewares() to also iterate over the tcp section of the config, adding each TCP middleware with type: 'tcp' so that the UI can render and filter them correctly. The existing filter buttons (All / HTTP / TCP) now work as expected for both protocols.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in
