### PR TITLE
Fix TCP Middlewares not being displayed on routes for tcp routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -3646,7 +3646,7 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
         tls_tcp = rdata.get('tls', {})
         apps.append({'id': app_id, 'name': rname, 'rule': rdata.get('rule', ''),
                      'service_name': svc_name, 'target': target,
-                     'middlewares': [], 'entryPoints': _to_list(rdata.get('entryPoints')),
+                     'middlewares': _to_list(rdata.get('middlewares')), 'entryPoints': _to_list(rdata.get('entryPoints')),
                      'protocol': 'tcp', 'tls': tls_tcp if isinstance(tls_tcp, dict) else ({} if tls_tcp else None), 'enabled': True,
                      'certResolver': tls_tcp.get('certResolver', '') if isinstance(tls_tcp, dict) else '',
                      'configFile': config_file, 'provider': 'file'})


### PR DESCRIPTION
## Summary

Traefik supports TCP middlewares (e.g., ipAllowList) defined under tcp.middlewares in the dynamic configuration.
- Routes API (/api/routes) – the _build_apps() function hardcoded middlewares: [] for TCP routers, so even if a TCP route referenced a middleware, the API response omitted that information. resulting in tcp middlewares not being displayed for routes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing
- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in
