### PR TITLE
feat: stop browsers autofilling config fields

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -132,6 +132,14 @@ Set `COOKIE_SECURE=true` whenever TM is accessed over HTTPS. Without it, browser
 
 ---
 
+## Browser autofill
+
+Every field in the app except the sign-in form is marked so browsers and password managers do not autofill it. Credential fields inside the app (API user and password, git backup token, CrowdSec key, the basic-auth and digest-auth generators) are marked `new-password`, which stops Chrome offering saved logins and prompting to save what you type there.
+
+The sign-in form is deliberately untouched, so your password manager still works where it should. The password change and TOTP fields in Settings keep their proper `current-password`, `new-password`, and `one-time-code` semantics.
+
+---
+
 ## Outbound requests (SSRF protection)
 
 Several features make TM issue outbound HTTP requests on your behalf - the connection test, the webhook test, the URL ping tool, and OIDC provider discovery. To prevent these from being used to reach cloud metadata endpoints, these fetchers reject:

--- a/templates/index.html
+++ b/templates/index.html
@@ -3844,6 +3844,46 @@ document.addEventListener('click', e => {
         closeMobileMenu();
     }
 });
+const _autofillAllowed = new Set(['pwCurrent', 'pwNew', 'pwConfirm', 'otpVerifyCode']);
+
+function _guardAutofillField(el) {
+    el.dataset.afGuarded = '1';
+    if (el.type === 'hidden' || _autofillAllowed.has(el.id)) return;
+    el.setAttribute('autocomplete', el.type === 'password' ? 'new-password' : 'off');
+    el.setAttribute('data-lpignore', 'true');
+    el.setAttribute('data-1p-ignore', 'true');
+    el.setAttribute('data-form-type', 'other');
+}
+
+function _sweepAutofillGuard() {
+    document.querySelectorAll('input:not([data-af-guarded]), textarea:not([data-af-guarded]), select:not([data-af-guarded])')
+        .forEach(_guardAutofillField);
+    document.querySelectorAll('form:not([data-af-guarded])').forEach(f => {
+        f.dataset.afGuarded = '1';
+        f.setAttribute('autocomplete', 'off');
+    });
+}
+
+let _afSweepQueued = false;
+
+function _queueAutofillSweep() {
+    if (_afSweepQueued) return;
+    _afSweepQueued = true;
+    requestAnimationFrame(() => {
+        _afSweepQueued = false;
+        _sweepAutofillGuard();
+    });
+}
+
+function _initAutofillGuard() {
+    _sweepAutofillGuard();
+    new MutationObserver(_queueAutofillSweep)
+        .observe(document.documentElement, { childList: true, subtree: true });
+}
+
+if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', _initAutofillGuard);
+else _initAutofillGuard();
+
 let _pwaInstallPrompt = null;
 
 if ('serviceWorker' in navigator) {

--- a/templates/modals/settings_modal.html
+++ b/templates/modals/settings_modal.html
@@ -390,7 +390,7 @@
                                         <div class="text-xs text-center" style="color:var(--muted)">
                                             Or enter manually: <code id="otpManualSecret" style="background:var(--border);padding:2px 6px;border-radius:3px;font-family:monospace;user-select:all"></code>
                                         </div>
-                                        <input type="text" id="otpVerifyCode" class="input-field" placeholder="Enter 6-digit code to confirm" inputmode="numeric" maxlength="6" style="text-align:center;letter-spacing:.2em;font-family:monospace">
+                                        <input type="text" id="otpVerifyCode" class="input-field" placeholder="Enter 6-digit code to confirm" autocomplete="one-time-code" inputmode="numeric" maxlength="6" style="text-align:center;letter-spacing:.2em;font-family:monospace">
                                         <div id="otpSetupMsg" class="hidden text-xs px-3 py-2 rounded-md"></div>
                                         <div class="flex gap-2">
                                             <button onclick="otpConfirmEnable()" class="nav-btn text-xs"><i class="ph-bold ph-check"></i> Verify &amp; Enable</button>


### PR DESCRIPTION
## Summary

Chrome autofills fields all over the app that have nothing to do with signing in: route and service names, `gitBackupUsername`, `settingsApiUser`, and the basic-auth and digest-auth generators. The cause is that the sign-in form has no username field, so Chrome looks elsewhere in the DOM for something username-shaped and pairs it with a password field. Fields inside the app that are `type="password"` also triggered save-password prompts on unrelated settings screens.

Every field is now marked on load and as new ones are rendered:

- `type="password"` fields get `autocomplete="new-password"`, which Chrome honours where a plain `off` is ignored.
- Everything else gets `autocomplete="off"` plus `data-lpignore` and `data-1p-ignore` so LastPass and 1Password stay out too.
- Forms get `autocomplete="off"`.

Many fields are rendered at runtime from JS template strings, so a one-shot sweep on `DOMContentLoaded` is not enough. A `MutationObserver` re-runs the sweep, batched into one pass per animation frame and skipping fields it has already handled, so DOM-heavy views like the Monaco editor do not pay per-node cost.

`login.html` is deliberately untouched so password managers still work where they should. The password change and TOTP fields in Settings keep `current-password`, `new-password` and `one-time-code`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Docs update
- [ ] Refactor / cleanup

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

Verified in Chrome against a Docker build: all 239 `input`/`textarea`/`select` elements in the rendered page carry an `autocomplete` value, none are left unmarked, and the four credential fields keep their intended semantics (`pwCurrent` → `current-password`, `pwNew`/`pwConfirm` → `new-password`, `otpVerifyCode` → `one-time-code`). A steady-state sweep over the full page measures 0.1 ms.

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in
