### PR TITLE
fix: route saves and bulk delete silently destroying config

### DIFF
--- a/app.py
+++ b/app.py
@@ -4167,6 +4167,46 @@ def _strip_empty_sections(config: dict) -> dict:
                 del config[proto]
     return config
 
+def _apply_managed_keys(target: dict, new: dict, managed: tuple) -> None:
+    for key in managed:
+        if key in new:
+            target[key] = new[key]
+        elif key in target:
+            del target[key]
+
+
+def _merge_router(section: dict, name: str, new: dict, managed: tuple) -> None:
+    existing = section.get(name)
+    if not isinstance(existing, dict):
+        section[name] = new
+        return
+    _apply_managed_keys(existing, new, managed)
+
+
+def _merge_service(section: dict, name: str, new_lb: dict, server_key: str, transport_name: str) -> None:
+    existing = section.get(name)
+    existing_lb = existing.get('loadBalancer') if isinstance(existing, dict) else None
+    if not isinstance(existing_lb, dict):
+        if isinstance(existing, dict) and existing:
+            return
+        section[name] = {'loadBalancer': new_lb}
+        return
+    servers = existing_lb.get('servers')
+    new_servers = new_lb.get('servers') or []
+    if isinstance(servers, list) and servers and isinstance(servers[0], dict) and new_servers:
+        servers[0][server_key] = new_servers[0][server_key]
+    else:
+        existing_lb['servers'] = new_servers
+    if 'passHostHeader' in new_lb:
+        existing_lb['passHostHeader'] = new_lb['passHostHeader']
+    elif 'passHostHeader' in existing_lb:
+        del existing_lb['passHostHeader']
+    if 'serversTransport' in new_lb:
+        existing_lb['serversTransport'] = new_lb['serversTransport']
+    elif existing_lb.get('serversTransport') == transport_name:
+        del existing_lb['serversTransport']
+
+
 def save_config(data, path=None):
     if path is None:
         path = CONFIG_PATH
@@ -4942,6 +4982,14 @@ def save_entry():
                     _prev_path = _resolve_config_path(orig_cfg_file)
                     _prev_src = load_config(_prev_path) if _prev_path else {}
             _prev_tcp_mws = _prev_src.get('tcp', {}).get('routers', {}).get(plain_original_id, {}).get('middlewares')
+            for sec in ('http', 'tcp', 'udp'):
+                prev_router = _prev_src.get(sec, {}).get('routers', {}).get(plain_original_id)
+                if not isinstance(prev_router, dict):
+                    continue
+                prev_svc = (prev_router.get('service') or '').split('@')[0].strip()
+                if prev_svc and prev_svc in _prev_src.get(sec, {}).get('services', {}):
+                    service_name = prev_svc
+                break
 
         if is_edit and plain_original_id and orig_cfg_file != cfg_filename:
             if agent:
@@ -5030,8 +5078,9 @@ def save_entry():
                     del existing_transports[transport_name]
                     if not existing_transports:
                         del config['http']['serversTransports']
-            config['http']['routers'][router_name]   = r
-            config['http']['services'][service_name] = {'loadBalancer': lb}
+            _merge_router(config['http']['routers'], router_name, r,
+                          ('rule', 'entryPoints', 'service', 'middlewares', 'tls'))
+            _merge_service(config['http']['services'], service_name, lb, 'url', transport_name)
 
         elif protocol == 'tcp':
             rule = tcp_rule or (f"HostSNI(`{subdomain}.{domain}`)" if subdomain else "HostSNI(`*`)")
@@ -5050,15 +5099,20 @@ def save_entry():
                 router_entry['tls'] = {'passthrough': True}
             elif use_tls_tcp:
                 router_entry['tls'] = {'certResolver': tcp_cert_resolver} if tcp_cert_resolver else {}
-            config['tcp']['routers'][router_name]   = router_entry
-            config['tcp']['services'][service_name] = {'loadBalancer': {'servers': [{'address': f"{target_ip}:{target_port}"}]}}
+            _merge_router(config['tcp']['routers'], router_name, router_entry,
+                          ('rule', 'entryPoints', 'service', 'middlewares', 'tls'))
+            _merge_service(config['tcp']['services'], service_name,
+                           {'servers': [{'address': f"{target_ip}:{target_port}"}]}, 'address', '')
 
         elif protocol == 'udp':
             udp_ep = request.form.get('udpEntryPoint', '').strip()
             config.setdefault('udp', {}).setdefault('routers', {})
             config['udp'].setdefault('services', {})
-            config['udp']['routers'][router_name]   = {'entryPoints': [udp_ep] if udp_ep else [], 'service': service_name}
-            config['udp']['services'][service_name] = {'loadBalancer': {'servers': [{'address': f"{target_ip}:{target_port}"}]}}
+            _merge_router(config['udp']['routers'], router_name,
+                          {'entryPoints': [udp_ep] if udp_ep else [], 'service': service_name},
+                          ('entryPoints', 'service'))
+            _merge_service(config['udp']['services'], service_name,
+                           {'servers': [{'address': f"{target_ip}:{target_port}"}]}, 'address', '')
 
         if agent:
             _agent_write_config(agent, cfg_filename, config)

--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -57,6 +57,12 @@ For TCP routes, enter a raw SNI rule (`HostSNI(\`*\`)` for passthrough). UDP rou
 
 Click the pencil icon on any route card, or open the detail panel and click **Edit**.
 
+Saving only rewrites the parts of the route the form owns: the rule, entry points, service reference, middlewares and TLS on the router, and the first server address, `passHostHeader` and the insecure-TLS transport on the service. Anything else you have written by hand is preserved - router `priority`, sticky sessions, health checks, additional servers, and your own `serversTransport`. An existing route also keeps the service name it already points at, rather than being renamed to `<name>-service`.
+
+::: warning Advanced service types
+If a router points at a `weighted`, `mirroring` or `failover` service instead of a `loadBalancer`, that service is left untouched, so editing the target field in the modal has no effect on it. Edit those services directly in the config file.
+:::
+
 ## Deleting a route
 
 Click the trash icon on the route card. The corresponding service entry in `dynamic.yml` is removed automatically.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1372,9 +1372,8 @@ async function saveRouteAjax(event) {
         if (_activeAgent) fd.append('agent_id', _activeAgent.id);
         const res = await fetch(form.action, { method:'POST', headers:{'X-Requested-With':'fetch'}, body: fd });
         const json = await res.json();
-        closeModal();
         showToast(json.message, json.ok ? 'success' : 'error');
-        if (json.ok) { refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
+        if (json.ok) { closeModal(); refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
     } catch(e) {
         showToast('Error saving route', 'error');
     } finally {
@@ -1419,9 +1418,8 @@ async function saveMwAjax(event) {
         if (_activeAgent) fd.append('agent_id', _activeAgent.id);
         const res = await fetch(form.action, { method:'POST', headers:{'X-Requested-With':'fetch'}, body: fd });
         const json = await res.json();
-        closeMwModal();
         showToast(json.message, json.ok ? 'success' : 'error');
-        if (json.ok) { _cachedMiddlewares = null; refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
+        if (json.ok) { closeMwModal(); _cachedMiddlewares = null; refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
     } catch(e) {
         showToast('Error saving middleware', 'error');
     } finally {
@@ -2180,13 +2178,50 @@ function _onWildcardToggle(checked) {
     if (base) { mainEl.value = base; sansEl.value = '*.' + base; }
 }
 
+function _applyHttpRuleToForm(rule) {
+    const isSimpleRule = /^(Host\(`[^`]+`\)(\s*\|\|\s*Host\(`[^`]+`\))*)$/.test(rule.trim());
+    if (!isSimpleRule && rule) {
+        setHttpRuleMode('advanced');
+        document.getElementById('httpRule').value = rule;
+    } else {
+        setHttpRuleMode('simple');
+    }
+    _updateRouteModalForAgent();
+    const domainsForMatch = _domainsForForm();
+    let subdomain = '';
+    const hostMatches = [...rule.matchAll(/Host\(`([^`]+)`\)/g)].map(m => m[1]);
+    const matchedDomains = [];
+    for (let fullHost of hostMatches) {
+        let found = false;
+        for (let d of domainsForMatch) {
+            if (fullHost.endsWith('.' + d)) { if (!subdomain) subdomain = fullHost.slice(0, -(d.length + 1)); matchedDomains.push(d); found = true; break; }
+            else if (fullHost === d) { matchedDomains.push(d); found = true; break; }
+        }
+        if (!found && !subdomain) subdomain = fullHost;
+    }
+    document.getElementById('subdomain').value = subdomain;
+    if (document.getElementById('domainChips')) {
+        _initDomainChips(matchedDomains.length ? matchedDomains : []);
+    } else {
+        const sel = document.getElementById('domainSelect');
+        if (sel && matchedDomains.length > 0) sel.value = matchedDomains[0];
+    }
+}
+
 async function cloneRoute(btn) {
     const app = JSON.parse(btn.getAttribute('data-app'));
     await openModal();
     document.getElementById('modalTitle').innerText = 'Clone Route';
+    document.getElementById('serviceName').value = (app.name || '') + '-copy';
+    const cfSel = document.getElementById('configFileSelect');
+    if (app.configFile) {
+        document.getElementById('configFile').value = app.configFile;
+        if (cfSel) cfSel.value = app.configFile;
+    }
     const proto = app.protocol || 'http';
     setProtocol(proto);
     if (proto === 'http') {
+        _applyHttpRuleToForm(app.rule || '');
         const targetScheme = (app.target || '').startsWith('https://') ? 'https' : 'http';
         let target = (app.target || '').replace('http://','').replace('https://','');
         const parts = target.split(':');
@@ -2223,6 +2258,7 @@ async function cloneRoute(btn) {
             tlsOptSel.value = app.tlsOptionsProfile || '';
         }
     } else if (proto === 'tcp') {
+        document.getElementById('tcpRule').value = app.rule || '';
         const target = (app.target || '').split(':');
         document.getElementById('targetIpTcp').value = target[0] || '';
         document.getElementById('targetPortTcp').value = target[1] || '';
@@ -2293,34 +2329,7 @@ async function handleEdit(btn) {
     setProtocol(proto);
 
     if (proto === 'http') {
-        let rule = app.rule || '';
-        const isSimpleRule = /^(Host\(`[^`]+`\)(\s*\|\|\s*Host\(`[^`]+`\))*)$/.test(rule.trim());
-        if (!isSimpleRule && rule) {
-            setHttpRuleMode('advanced');
-            document.getElementById('httpRule').value = rule;
-        } else {
-            setHttpRuleMode('simple');
-        }
-        _updateRouteModalForAgent();
-        const domainsForMatch = _domainsForForm();
-        let subdomain = '';
-        const hostMatches = [...rule.matchAll(/Host\(`([^`]+)`\)/g)].map(m => m[1]);
-        const matchedDomains = [];
-        for (let fullHost of hostMatches) {
-            let found = false;
-            for (let d of domainsForMatch) {
-                if (fullHost.endsWith('.' + d)) { if (!subdomain) subdomain = fullHost.slice(0, -(d.length + 1)); matchedDomains.push(d); found = true; break; }
-                else if (fullHost === d) { matchedDomains.push(d); found = true; break; }
-            }
-            if (!found && !subdomain) subdomain = fullHost;
-        }
-        document.getElementById('subdomain').value = subdomain;
-        if (document.getElementById('domainChips')) {
-            _initDomainChips(matchedDomains.length ? matchedDomains : []);
-        } else {
-            const sel = document.getElementById('domainSelect');
-            if (sel && matchedDomains.length > 0) sel.value = matchedDomains[0];
-        }
+        _applyHttpRuleToForm(app.rule || '');
 
         const targetScheme = (app.target || '').startsWith('https://') ? 'https' : 'http';
         let target = app.target.replace('http://','').replace('https://','');
@@ -3022,15 +3031,24 @@ async function bulkDelete() {
     if (!ids.length) return;
     if (!await _confirm(`Delete ${ids.length} route${ids.length > 1 ? 's' : ''}?`, 'Bulk Delete', 'Delete')) return;
     const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
+    let failed = 0;
     for (const id of ids) {
         const card = document.querySelector(`.route-card[data-routekey="${CSS.escape(id)}"]`);
         const cf   = card?.dataset.configfile || '';
         const data = new FormData();
         data.append('csrf_token', csrf);
         if (cf) data.append('configFile', cf);
-        await fetch('/delete/' + encodeURIComponent(id), { method:'POST', headers:{'X-Requested-With':'fetch'}, body: data });
+        if (_activeAgent) data.append('agent_id', _activeAgent.id);
+        try {
+            const res  = await fetch('/delete/' + encodeURIComponent(id), { method:'POST', headers:{'X-Requested-With':'fetch'}, body: data });
+            const json = await res.json();
+            if (!res.ok || !json.ok) failed++;
+        } catch(e) { failed++; }
     }
+    if (failed) showToast(`${failed} of ${ids.length} route${ids.length > 1 ? 's' : ''} could not be deleted.`, 'error');
+    else showToast(`Deleted ${ids.length} route${ids.length > 1 ? 's' : ''}.`, 'success');
     _bulkSelected.clear(); updateBulkBar(); refreshRoutes(); fetchNotifications();
+    if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData();
 }
 let _mwViewMode = 'grid';
 let _allMiddlewares = {{ middlewares | tojson | safe }};


### PR DESCRIPTION
## Summary

Four bugs where the UI silently destroyed data or acted on the wrong target.

**Route saves destroyed config the modal cannot display.** `save_entry` rebuilt the router and the service from the form on every save, so anything the form does not know about was dropped: router `priority` and `observability`, and on the service side sticky sessions, health checks, additional servers and user-authored `serversTransport`. It also set `service_name = f"{svc_name}-service"` unconditionally, so a hand-written route whose service is named differently had its original service deleted by the rename cleanup on the first save from the UI - which meant a merge alone would not have fixed it.

Router and service entries are now merged in place rather than replaced, which also preserves surrounding comments and formatting, and an existing router keeps the service name it already points at. The form still owns `rule`, `entryPoints`, `service`, `middlewares` and `tls` on the router, and the first server address, `passHostHeader` and its own generated transport on the service, so clearing those in the modal still removes them from the YAML. A service that is `weighted`, `mirroring` or `failover` rather than a `loadBalancer` is now left untouched instead of being replaced.

**Bulk delete deleted on the wrong server.** `bulkDelete` never sent `agent_id`, unlike `deleteRoute`, so with a remote server selected `delete_entry` fell through to the Host branch and deleted a same-named route from the Host config while the intended remote route survived. It also ignored the response entirely, so every failure was silent. It now sends `agent_id`, checks the result and reports how many deletions failed. `bulkEnable` and `bulkDisable` were not affected - they delegate to `toggleRoute`, which already passes `agent_id`.

**Modals wiped a filled-in form when a save was rejected.** `saveRouteAjax` and `saveMwAjax` called `closeModal()`/`closeMwModal()` before checking `json.ok`. Both now close only on success, matching `saveTlsOption`.

**Clone Route did not clone the route identity.** It filled in the target but never the service name, the rule or the config file, so an advanced HTTP rule vanished and the clone came up unnamed. The HTTP rule parsing `handleEdit` already did is now a shared helper used by both.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Refactor / cleanup

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

Tested against a Docker build with a config file containing a hand-written route (`priority: 42`, two servers, sticky, health check, a YAML comment) and saving it through `/save` exactly as the modal does. Before: the service was renamed to `myapp-service` and reduced to a single server with everything else gone. After: the target updates, and the service name, second server, sticky, health check, `priority` and the comment all survive. Verified the merge is not append-only - clearing middlewares, disabling TLS and re-enabling `passHostHeader` still remove those keys - and that creating a new route still produces `<name>-service` as before, with a backup written on every save. A `weighted` service is confirmed untouched.

Bulk delete against a live remote agent was not exercised; that change is a one-line addition mirroring `deleteRoute` plus response checking. The modal and clone changes were reviewed rather than driven in a browser; all element ids the clone path writes to were checked against the templates.

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in

---

By the way, I found a few more things I'd like to fix if you're fine with that :) I'll keep them as separate PRs, as per your rule: "Keep PRs focused - one fix or feature per PR."

I've also got a couple of features I'd love to see and would be happy to work on.

Feel free to reach me on Discord if you have any questions (Discord user id `752133194320445493`).

Love the project so far!
