### PR TITLE
fix: blank Routes tab on fresh install and when filters match nothing

### DIFF
--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -11,6 +11,10 @@ The **Routes** tab (also called Services) is the main management interface. It d
 - Multi-domain routes show each domain as a separate pill badge; clicking a domain or target copies it to the clipboard
 - Full detail view via the info button - shows live Traefik status, service health, and raw config
 
+## Empty state
+
+When no routes exist yet - such as on a fresh install - the tab shows a prompt with an **Add Route** button instead of a blank grid. When a search or filter matches nothing, it shows a "No routes match your filters" message instead.
+
 ## Filtering
 
 The filter bar above the grid lets you narrow routes by:

--- a/templates/index.html
+++ b/templates/index.html
@@ -841,6 +841,7 @@ function pickRouteDomain(val, label) {
 
 function filterRoutes() {
     const q = document.getElementById('searchRoutes').value.toLowerCase();
+    let visible = 0;
     for (const card of _routeCardEls) {
         const name    = card.dataset.name || '';
         const proto   = card.dataset.protocol || '';
@@ -852,6 +853,21 @@ function filterRoutes() {
             (!currentRouteDomainFilter || domains.some(d => d === currentRouteDomainFilter || d.endsWith('.' + currentRouteDomainFilter))) &&
             (currentRouteStatusFilter === 'all' || (currentRouteStatusFilter === 'active' && enabled) || (currentRouteStatusFilter === 'inactive' && !enabled));
         card.style.display = show ? '' : 'none';
+        if (show) visible++;
+    }
+    const emptyEl = document.getElementById('routeEmpty');
+    if (emptyEl && _routeCardEls.length > 0) {
+        if (visible === 0) {
+            const t = document.getElementById('routeEmptyText');
+            const sub = document.getElementById('routeEmptySub');
+            const cta = document.getElementById('routeEmptyCta');
+            if (t) t.textContent = 'No routes match your filters';
+            if (sub) sub.style.display = 'none';
+            if (cta) cta.style.display = 'none';
+            emptyEl.style.display = '';
+        } else {
+            emptyEl.style.display = 'none';
+        }
     }
 }
 
@@ -1738,7 +1754,16 @@ function renderRouteGrid(apps) {
     if (apps.length === 0) {
         grid.className = 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4';
         grid.innerHTML = '';
-        if (emptyEl) emptyEl.style.display = '';
+        _routeCardEls = [];
+        if (emptyEl) {
+            const t = document.getElementById('routeEmptyText');
+            const sub = document.getElementById('routeEmptySub');
+            const cta = document.getElementById('routeEmptyCta');
+            if (t) t.textContent = _activeAgent ? 'No routes on this server yet' : 'No routes yet';
+            if (sub) sub.style.display = '';
+            if (cta) cta.style.display = 'inline-flex';
+            emptyEl.style.display = '';
+        }
         return;
     }
     if (emptyEl) emptyEl.style.display = 'none';

--- a/templates/tabs/tab_services.html
+++ b/templates/tabs/tab_services.html
@@ -61,4 +61,13 @@
     <div id="configErrorBanner" style="display:none;background:rgba(234,179,8,0.08);border:1px solid rgba(234,179,8,0.3);border-radius:10px;padding:12px 16px;margin-bottom:16px"></div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4" id="routeGrid"></div>
+
+    <div id="routeEmpty" class="text-center py-20" style="display:none;color:var(--muted)">
+        <i class="ph-light ph-list-plus text-6xl block mb-4 opacity-30"></i>
+        <p class="text-base font-medium" id="routeEmptyText">No routes yet</p>
+        <p class="text-sm mt-1 mb-5" id="routeEmptySub">Create your first route to start managing your Traefik proxy.</p>
+        <button onclick="openModal()" id="routeEmptyCta" class="nav-btn nav-btn-primary" style="display:inline-flex">
+            <i class="ph-bold ph-plus"></i> Add Route
+        </button>
+    </div>
 </div>


### PR DESCRIPTION
## Summary

`renderRouteGrid` toggled an element with id `routeEmpty` to show an empty state, but that element did not exist in any template. So the Routes tab - the default landing tab - rendered a completely blank grid when there were no routes, which is exactly what a fresh install shows. Filtering or searching down to zero matches left the same blank area with no explanation.

This adds the missing `routeEmpty` element with an **Add Route** call to action, shown when no routes exist, and extends `filterRoutes` to reuse the same element with a "No routes match your filters" message (without the call to action) when a search or filter hides every card. The headline adapts to "No routes on this server yet" when a remote server is selected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Refactor / cleanup

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

Tested against a Docker build with an empty config. Fresh-install case: the Routes tab shows "No routes yet", the sub-text and the Add Route button, confirmed rendered (visible, opacity 1, 338px tall) and the button opens the Add Route modal. No-match case (verified by driving `filterRoutes` with a card present): a non-matching search shows "No routes match your filters" with the call to action hidden and the card hidden; a matching search hides the empty state and shows the card again. The true-empty branch is left untouched by `filterRoutes` (its `_routeCardEls.length > 0` guard), so the Add Route prompt is not replaced by the filter message.

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in
