### PR TITLE
fix: parse JSON-format access logs in the Logs tab

### DIFF
--- a/docs/tab-logs.md
+++ b/docs/tab-logs.md
@@ -49,6 +49,8 @@ accessLog:
   format: common
 ```
 
+Both the `common` (CLF text) and `json` access log formats are parsed into cards. Lines that match neither are shown as-is.
+
 Then point traefik-manager at the log file via the `ACCESS_LOG_PATH` environment variable (default: `/app/logs/access.log`).
 
 :::tabs

--- a/templates/index.html
+++ b/templates/index.html
@@ -5187,7 +5187,37 @@ const HTTP_STATUS = {
     500:'Internal Server Error',501:'Not Implemented',502:'Bad Gateway',503:'Service Unavailable',504:'Gateway Timeout'
 };
 
+function _fmtLogDuration(ns) {
+    if (!ns) return '';
+    if (ns >= 1e9) return (ns / 1e9).toFixed(2) + 's';
+    if (ns >= 1e6) return Math.round(ns / 1e6) + 'ms';
+    if (ns >= 1e3) return Math.round(ns / 1e3) + 'µs';
+    return ns + 'ns';
+}
+
 function parseLogLine(raw) {
+    const trimmed = raw.trimStart();
+    if (trimmed.startsWith('{')) {
+        try {
+            const j = JSON.parse(trimmed);
+            if (j.RequestMethod || j.RequestPath || j.DownstreamStatus) {
+                const durNs = typeof j.Duration === 'number' ? j.Duration : parseInt(j.Duration) || 0;
+                const size = j.DownstreamContentSize != null ? j.DownstreamContentSize : (j.OriginContentSize != null ? j.OriginContentSize : '');
+                return {
+                    ip: j.ClientHost || (j.ClientAddr || '').split(':')[0] || '',
+                    date: j.StartUTC || j.StartLocal || j.time || '',
+                    method: j.RequestMethod || '',
+                    path: j.RequestPath || '',
+                    status: parseInt(j.DownstreamStatus) || parseInt(j.OriginStatus) || 0,
+                    size: String(size),
+                    service: j.ServiceName || '',
+                    serviceUrl: j.ServiceURL || j.ServiceAddr || '',
+                    duration: _fmtLogDuration(durNs),
+                    raw
+                };
+            }
+        } catch (_) {}
+    }
     const full = raw.match(
         /^(\S+) \S+ \S+ \[([^\]]+)\] "(\S+) (\S+)[^"]*" (\d+) (\S+) "[^"]*" "[^"]*" \S+ "([^"]*)" "([^"]*)" (\S+)/
     );


### PR DESCRIPTION
## Summary

`parseLogLine` only understood Traefik's `common` (CLF text) access log format. With `accessLog.format: json` - a common and Traefik-recommended configuration - every line failed to parse, so the Logs tab fell back to a raw one-line-per-entry dump: no method, status, path or service columns, no status colouring, no stats bar, and no geo lookup. The tab was effectively broken for anyone using JSON logs.

`parseLogLine` now detects a JSON line and maps Traefik's access-log fields (`ClientHost`, `RequestMethod`, `RequestPath`, `DownstreamStatus`, `DownstreamContentSize`, `ServiceName`, `ServiceURL`, `Duration`, `StartUTC`) onto the same object shape the rest of the tab already consumes, formatting the nanosecond `Duration` into a short human string (`12ms`, `812µs`). JSON runtime log lines (`level`/`msg`, no request fields) and anything unrecognised still fall through to the existing raw view.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Docs update
- [ ] Refactor / cleanup

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

Ran `parseLogLine` against representative inputs: a full JSON access-log line (parsed - method, status, IP, service, `Duration` 12345678ns → `12ms`, size all correct), a partial JSON line with no service and `Duration` 812000ns → `812µs`, a JSON runtime log line with only `level`/`msg` (correctly returns `null` so it shows raw rather than being mis-parsed as a request), a full CLF line and a basic CLF line (both still parse exactly as before - no regression to text-format handling), and a garbage line (`null`). Not exercised against a live Traefik JSON log file end to end.

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in
