### PR TITLE
fix: close route, middleware and settings modals with Escape

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2010,7 +2010,7 @@ function _customDomainPrompt(btn) {
     };
     input.addEventListener('keydown', e => {
         if (e.key === 'Enter') { e.preventDefault(); commit(); }
-        else if (e.key === 'Escape') { if (window._domainChipRender) window._domainChipRender(); }
+        else if (e.key === 'Escape' && input.value) { e.stopPropagation(); input.value = ''; if (window._domainChipRender) window._domainChipRender(); }
     });
     input.addEventListener('blur', () => { if (input.isConnected) commit(); });
 }
@@ -3598,8 +3598,28 @@ function _isTyping() {
     return t === 'INPUT' || t === 'TEXTAREA' || t === 'SELECT' || document.activeElement?.isContentEditable;
 }
 
+function _closeTopModal() {
+    const modals = [
+        ['tlsOptionsModal', closeTlsOptionModal],
+        ['appModal', closeModal],
+        ['mwModal', closeMwModal],
+        ['settingsModal', closeSettingsModal],
+        ['rmEditModal', window.rmCloseEditModal],
+        ['rmGroupsModal', window.rmCloseGroupsModal],
+    ];
+    for (const [id, close] of modals) {
+        const el = document.getElementById(id);
+        if (el && getComputedStyle(el).display !== 'none' && typeof close === 'function') {
+            close();
+            return true;
+        }
+    }
+    return false;
+}
+
 document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
+        if (_closeTopModal()) return;
         closeRouteDetail();
         closeMwDetail();
         closeSvcDetail();


### PR DESCRIPTION
## Summary

The global Escape handler closed the read-only detail panels and the shortcuts panel, but none of the editing modals. The route and middleware modals also had no backdrop-click close (only the settings modal did), so once opened they could only be dismissed with the X or Cancel button - no keyboard exit at all.

Escape now closes the topmost open modal - route, middleware, settings, TLS options, and the dashboard group and route-edit modals - through each modal's own close function, so per-modal cleanup (for example the settings modal restoring `body` scroll) still runs.

The custom-domain chip input (the free-type "+" field) has its own Escape handler that discards the in-progress entry. It now stops propagation only while it has a value, giving a natural two-stage behaviour: the first Escape clears the field, a second Escape closes the modal.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

No `docs/` change: there is no page documenting modal dismissal or keyboard shortcuts, and this only brings the editing modals in line with the detail panels that already close on Escape.

## Testing

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

Driven in Chrome against a Docker build. Route modal: opens, Escape closes it. Middleware modal: opens, Escape closes it. Settings modal: opens (with `body` overflow locked to `hidden`), Escape closes it and `body` overflow is restored to empty - confirming the close function ran, not just a hide. Custom-domain chip input: with text typed, Escape clears the field and leaves the modal open; a subsequent Escape closes the modal. When several modals are checked, the topmost open one is the one that closes.

## Checklist

- [x] Targeted the correct branch (`dev` for new features/fixes, `main` for docs/stable fixes)
- [x] Updated relevant docs in `docs/` if behaviour changed (n/a - no page covers this)
- [x] No commented-out code or debug statements left in
