### PR TITLE
fix: restore the active server across reloads

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -493,6 +493,8 @@ function _updateServerSwitcherList(agents) {
 function switchServer(agentId) {
     const agent = agentId ? (_agentRegistry[agentId] || null) : null;
     _activeAgent = agent;
+    if (agent) localStorage.setItem('tm_active_agent', agent.id);
+    else localStorage.removeItem('tm_active_agent');
     _cachedEntrypoints = null;
     _cachedMiddlewares = null;
     _cachedCertResolvers = null;
@@ -5552,11 +5554,21 @@ function _initMobileFilterBars() {
     if (typeof applyUiPrefs === 'function') applyUiPrefs();
     if (typeof _applyDocsLinkVisibility === 'function') _applyDocsLinkVisibility();
     _initMobileFilterBars();
-    refreshRoutes();
+    const _storedAgentId = localStorage.getItem('tm_active_agent');
+    if (!_storedAgentId) refreshRoutes();
     loadOverviewStats();
     checkManagerVersion();
     fetchNotifications();
-    fetch('/api/agents').then(r => r.json()).then(d => _updateServerSwitcherList(d.agents || [])).catch(() => {});
+    fetch('/api/agents').then(r => r.json()).then(d => {
+        const agents = d.agents || [];
+        _updateServerSwitcherList(agents);
+        if (_storedAgentId && agents.some(a => a.id === _storedAgentId)) {
+            switchServer(_storedAgentId);
+        } else if (_storedAgentId) {
+            localStorage.removeItem('tm_active_agent');
+            refreshRoutes();
+        }
+    }).catch(() => { if (_storedAgentId) refreshRoutes(); });
     setInterval(fetchNotifications, 60000);
 })();
 


### PR DESCRIPTION
## Summary

The multi-server switcher only ever set `_activeAgent` from click handlers — nothing restored it on page load, so every reload silently dropped multi-server users back to the **Host** view and you had to re-pick your server each time.

This persists the active agent id to `localStorage` on `switchServer()` (and clears it when switching back to Host), then restores it on load, falling back to Host if the stored agent no longer exists. When a restore is pending the load-time route fetch is skipped, so exactly one `refreshRoutes()` runs against the correct server — no duplicate `/api/routes` request and no flash of Host routes on reload.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing

Scenarios verified:
- Single-server users (no agents): unchanged — Host still loads eagerly.
- Reload with an agent active: switcher and route grid both come back on the agent; no Host flash, no duplicate fetch.
- Stored agent removed in Settings, then reload: cleanly falls back to Host.

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] PR targets the `dev` branch (never `main`)
- [ ] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in