### PR TITLE
fix: warn when a route's service type isn't editable in the modal

### DIFF
--- a/app.py
+++ b/app.py
@@ -4244,6 +4244,14 @@ def _to_list(val, default=None):
         return [val]
     return list(val) if hasattr(val, '__iter__') else []
 
+def _service_type(svc_def) -> str:
+    if isinstance(svc_def, dict):
+        for t in ('weighted', 'mirroring', 'failover'):
+            if t in svc_def:
+                return t
+    return 'loadBalancer'
+
+
 def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=None, extra_udp_svcs=None, api_svc_urls=None):
     apps = []
     http_config = config.get('http', {})
@@ -4279,6 +4287,7 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
                      'tlsDomains': tls_http.get('domains', []) if isinstance(tls_http, dict) else [],
                      'tlsOptionsProfile': tls_http.get('options', '') if isinstance(tls_http, dict) else '',
                      'insecureSkipVerify': insecure,
+                     'serviceType': _service_type(http_svcs.get(svc_key)),
                      'configFile': config_file, 'provider': 'file'})
     tcp_svcs = dict(config.get('tcp', {}).get('services', {}))
     if extra_tcp_svcs:
@@ -4302,6 +4311,7 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
                      'middlewares': _to_list(rdata.get('middlewares')), 'entryPoints': _to_list(rdata.get('entryPoints')),
                      'protocol': 'tcp', 'tls': tls_tcp if isinstance(tls_tcp, dict) else ({} if tls_tcp else None), 'enabled': True,
                      'certResolver': tls_tcp.get('certResolver', '') if isinstance(tls_tcp, dict) else '',
+                     'serviceType': _service_type(tcp_svcs.get(svc_key)),
                      'configFile': config_file, 'provider': 'file'})
     udp_svcs = dict(config.get('udp', {}).get('services', {}))
     if extra_udp_svcs:
@@ -4323,6 +4333,7 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
                      'service_name': svc_name, 'target': target,
                      'middlewares': [], 'entryPoints': _to_list(rdata.get('entryPoints')),
                      'protocol': 'udp', 'tls': False, 'enabled': True,
+                     'serviceType': _service_type(udp_svcs.get(svc_key)),
                      'configFile': config_file, 'provider': 'file'})
     return apps
 
@@ -4469,6 +4480,7 @@ def _build_all_apps(include_external=True, include_internal=False):
                              'entryPoints': router.get('entryPoints', []),
                              'protocol': 'http', 'tls': bool(router.get('tls')), 'enabled': False,
                              'passHostHeader': svc.get('loadBalancer', {}).get('passHostHeader', True),
+                             'serviceType': _service_type(svc),
                              'configFile': cf, 'provider': 'file', 'entrypointMiddlewares': []})
         elif proto == 'tcp':
             servers = svc.get('loadBalancer', {}).get('servers', [])
@@ -4477,6 +4489,7 @@ def _build_all_apps(include_external=True, include_internal=False):
                              'service_name': svc_name, 'target': target,
                              'middlewares': router.get('middlewares', []), 'entryPoints': router.get('entryPoints', []),
                              'protocol': 'tcp', 'tls': bool(router.get('tls')), 'enabled': False,
+                             'serviceType': _service_type(svc),
                              'configFile': cf, 'provider': 'file'})
         else:
             servers = svc.get('loadBalancer', {}).get('servers', [])
@@ -4485,6 +4498,7 @@ def _build_all_apps(include_external=True, include_internal=False):
                              'service_name': svc_name, 'target': target,
                              'middlewares': [], 'entryPoints': router.get('entryPoints', []),
                              'protocol': 'udp', 'tls': False, 'enabled': False,
+                             'serviceType': _service_type(svc),
                              'configFile': cf, 'provider': 'file'})
     return all_apps, all_middlewares
 
@@ -5734,6 +5748,7 @@ def api_agent_routes(agent_id):
                              'entryPoints': router.get('entryPoints', []),
                              'protocol': 'http', 'tls': bool(router.get('tls')), 'enabled': False,
                              'passHostHeader': svc.get('loadBalancer', {}).get('passHostHeader', True),
+                             'serviceType': _service_type(svc),
                              'configFile': cf, 'provider': 'file', 'entrypointMiddlewares': []})
             else:
                 target = servers[0].get('address', 'N/A') if servers else 'N/A'
@@ -5742,6 +5757,7 @@ def api_agent_routes(agent_id):
                              'middlewares': router.get('middlewares', []) if proto == 'tcp' else [],
                              'entryPoints': router.get('entryPoints', []),
                              'protocol': proto, 'tls': bool(router.get('tls')) if proto == 'tcp' else False,
+                             'serviceType': _service_type(svc),
                              'enabled': False, 'configFile': cf, 'provider': 'file'})
 
         return jsonify({'apps': apps, 'middlewares': middlewares, 'configErrors': config_errors})

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -607,6 +607,8 @@ label { display: block; font-size: 12px; font-weight: 600; color: var(--muted); 
 .notif-mark-read { font-size: 11px; color: var(--blue); background: none; border: none; cursor: pointer; padding: 2px 6px; border-radius: 4px; transition: background 0.15s; }
 .notif-mark-read:hover { background: rgba(36,161,222,0.1); }
 .notif-list { overflow-y: auto; max-height: 420px; padding: 6px; }
+.modal-inline-notice { display: flex; align-items: flex-start; gap: 8px; padding: 10px 12px; border-radius: 8px; font-size: 12px; line-height: 1.5; color: var(--yellow); background: rgba(210,153,34,0.1); border: 1px solid rgba(210,153,34,0.3); }
+.modal-inline-notice i { margin-top: 1px; flex-shrink: 0; }
 .notif-empty { text-align: center; padding: 40px 16px; color: var(--muted); font-size: 12px; }
 .notif-item { display: flex; gap: 10px; align-items: flex-start; padding: 10px 10px; border-radius: 8px; transition: background 0.1s; }
 .notif-item:hover { background: var(--input-bg); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -914,9 +914,24 @@ function setHttpRuleMode(mode) {
     if (!isAdv) { const el = document.getElementById('httpRule'); if (el) el.value = ''; }
 }
 
+function _applyServiceTypeNotice(svcType) {
+    const editable = !svcType || svcType === 'loadBalancer';
+    const notice = document.getElementById('svcTypeNotice');
+    if (notice) notice.style.display = editable ? 'none' : 'flex';
+    if (!editable) {
+        const text = document.getElementById('svcTypeNoticeText');
+        if (text) text.textContent = `This route points at a ${svcType} service, which can't be edited here. The target field is ignored on save — use the Raw YAML editor to change it.`;
+    }
+    ['targetIp', 'targetPort', 'targetIpTcp', 'targetPortTcp', 'targetIpUdp', 'targetPortUdp'].forEach(id => {
+        const el = document.getElementById(id);
+        if (el) el.disabled = !editable;
+    });
+}
+
 async function openModal() {
     document.getElementById('isEdit').value = 'false';
     document.getElementById('modalTitle').innerText = 'Add Route';
+    _applyServiceTypeNotice('loadBalancer');
     document.getElementById('originalId').value = '';
     ['serviceName','subdomain','targetIp','targetPort','middlewares','tcpRule','httpRule'].forEach(id => {
         const el = document.getElementById(id);
@@ -2352,6 +2367,7 @@ async function handleEdit(btn) {
 
     const proto = app.protocol || 'http';
     setProtocol(proto);
+    _applyServiceTypeNotice(app.serviceType);
 
     if (proto === 'http') {
         _applyHttpRuleToForm(app.rule || '');

--- a/templates/modals/route_modal.html
+++ b/templates/modals/route_modal.html
@@ -36,6 +36,11 @@
                     </div>
                 </div>
 
+                <div id="svcTypeNotice" class="modal-inline-notice" style="display:none">
+                    <i class="ph-bold ph-warning-circle"></i>
+                    <span id="svcTypeNoticeText"></span>
+                </div>
+
                 <div>
                     <label>Route / Service Name</label>
                     <input type="text" name="serviceName" id="serviceName" required class="input-field" placeholder="e.g. my-app">


### PR DESCRIPTION
## Summary

Routes backed by a **weighted**, **mirroring** or **failover** service have no `loadBalancer`, so the route modal's *Target* field was silently ignored on save — the merge correctly preserves the service untouched, but the UI gave no indication, so editing the target looked like it worked and did nothing.

This exposes a `serviceType` for every route from the routes API (host, disabled and agent routes alike). When the service isn't a plain `loadBalancer`, the route modal shows a notice and disables the target fields. Rule, middlewares, TLS and entry points stay fully editable — only the target is locked, with a pointer to the Raw YAML editor for changing it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing

Scenarios verified:
- `loadBalancer` route: unchanged, fully editable.
- weighted/mirroring/failover route: notice shown, target fields disabled; saving updates the router (rule/middlewares/TLS/entry points) and leaves the service definition intact.

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] PR targets the `dev` branch (never `main`)
- [ ] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in