### PR TITLE
fix: don't apply another route's wildcard cert domains when editing

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-const Version = "1.7.2"
+const Version = "1.7.3"
 
 type Config struct {
 	APIKey                 string

--- a/app.py
+++ b/app.py
@@ -4167,6 +4167,46 @@ def _strip_empty_sections(config: dict) -> dict:
                 del config[proto]
     return config
 
+def _apply_managed_keys(target: dict, new: dict, managed: tuple) -> None:
+    for key in managed:
+        if key in new:
+            target[key] = new[key]
+        elif key in target:
+            del target[key]
+
+
+def _merge_router(section: dict, name: str, new: dict, managed: tuple) -> None:
+    existing = section.get(name)
+    if not isinstance(existing, dict):
+        section[name] = new
+        return
+    _apply_managed_keys(existing, new, managed)
+
+
+def _merge_service(section: dict, name: str, new_lb: dict, server_key: str, transport_name: str) -> None:
+    existing = section.get(name)
+    existing_lb = existing.get('loadBalancer') if isinstance(existing, dict) else None
+    if not isinstance(existing_lb, dict):
+        if isinstance(existing, dict) and existing:
+            return
+        section[name] = {'loadBalancer': new_lb}
+        return
+    servers = existing_lb.get('servers')
+    new_servers = new_lb.get('servers') or []
+    if isinstance(servers, list) and servers and isinstance(servers[0], dict) and new_servers:
+        servers[0][server_key] = new_servers[0][server_key]
+    else:
+        existing_lb['servers'] = new_servers
+    if 'passHostHeader' in new_lb:
+        existing_lb['passHostHeader'] = new_lb['passHostHeader']
+    elif 'passHostHeader' in existing_lb:
+        del existing_lb['passHostHeader']
+    if 'serversTransport' in new_lb:
+        existing_lb['serversTransport'] = new_lb['serversTransport']
+    elif existing_lb.get('serversTransport') == transport_name:
+        del existing_lb['serversTransport']
+
+
 def save_config(data, path=None):
     if path is None:
         path = CONFIG_PATH
@@ -4942,6 +4982,14 @@ def save_entry():
                     _prev_path = _resolve_config_path(orig_cfg_file)
                     _prev_src = load_config(_prev_path) if _prev_path else {}
             _prev_tcp_mws = _prev_src.get('tcp', {}).get('routers', {}).get(plain_original_id, {}).get('middlewares')
+            for sec in ('http', 'tcp', 'udp'):
+                prev_router = _prev_src.get(sec, {}).get('routers', {}).get(plain_original_id)
+                if not isinstance(prev_router, dict):
+                    continue
+                prev_svc = (prev_router.get('service') or '').split('@')[0].strip()
+                if prev_svc and prev_svc in _prev_src.get(sec, {}).get('services', {}):
+                    service_name = prev_svc
+                break
 
         if is_edit and plain_original_id and orig_cfg_file != cfg_filename:
             if agent:
@@ -5030,8 +5078,9 @@ def save_entry():
                     del existing_transports[transport_name]
                     if not existing_transports:
                         del config['http']['serversTransports']
-            config['http']['routers'][router_name]   = r
-            config['http']['services'][service_name] = {'loadBalancer': lb}
+            _merge_router(config['http']['routers'], router_name, r,
+                          ('rule', 'entryPoints', 'service', 'middlewares', 'tls'))
+            _merge_service(config['http']['services'], service_name, lb, 'url', transport_name)
 
         elif protocol == 'tcp':
             rule = tcp_rule or (f"HostSNI(`{subdomain}.{domain}`)" if subdomain else "HostSNI(`*`)")
@@ -5050,15 +5099,20 @@ def save_entry():
                 router_entry['tls'] = {'passthrough': True}
             elif use_tls_tcp:
                 router_entry['tls'] = {'certResolver': tcp_cert_resolver} if tcp_cert_resolver else {}
-            config['tcp']['routers'][router_name]   = router_entry
-            config['tcp']['services'][service_name] = {'loadBalancer': {'servers': [{'address': f"{target_ip}:{target_port}"}]}}
+            _merge_router(config['tcp']['routers'], router_name, router_entry,
+                          ('rule', 'entryPoints', 'service', 'middlewares', 'tls'))
+            _merge_service(config['tcp']['services'], service_name,
+                           {'servers': [{'address': f"{target_ip}:{target_port}"}]}, 'address', '')
 
         elif protocol == 'udp':
             udp_ep = request.form.get('udpEntryPoint', '').strip()
             config.setdefault('udp', {}).setdefault('routers', {})
             config['udp'].setdefault('services', {})
-            config['udp']['routers'][router_name]   = {'entryPoints': [udp_ep] if udp_ep else [], 'service': service_name}
-            config['udp']['services'][service_name] = {'loadBalancer': {'servers': [{'address': f"{target_ip}:{target_port}"}]}}
+            _merge_router(config['udp']['routers'], router_name,
+                          {'entryPoints': [udp_ep] if udp_ep else [], 'service': service_name},
+                          ('entryPoints', 'service'))
+            _merge_service(config['udp']['services'], service_name,
+                           {'servers': [{'address': f"{target_ip}:{target_port}"}]}, 'address', '')
 
         if agent:
             _agent_write_config(agent, cfg_filename, config)

--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ from io import StringIO
 from cryptography.fernet import Fernet, InvalidToken
 
 GITHUB_REPO  = "chr0nzz/traefik-manager"
-APP_VERSION  = "1.7.2"
+APP_VERSION  = "1.7.3"
 
 
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,8 +33,9 @@ export default defineConfig({
       { text: 'API', link: '/api' },
       { text: 'UI Examples', link: '/ui-examples' },
       {
-        text: 'v1.7.2',
+        text: 'v1.7.3',
         items: [
+          { text: 'v1.7.3', link: 'https://github.com/chr0nzz/traefik-manager/releases/tag/v1.7.3' },
           { text: 'v1.7.2', link: 'https://github.com/chr0nzz/traefik-manager/releases/tag/v1.7.2' },
           { text: 'v1.7.1', link: 'https://github.com/chr0nzz/traefik-manager/releases/tag/v1.7.1' },
           { text: 'v1.7.0', link: 'https://github.com/chr0nzz/traefik-manager/releases/tag/v1.7.0' },

--- a/docs/public/openapi.yaml
+++ b/docs/public/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Traefik Manager API
-  version: 1.7.2
+  version: 1.7.3
   description: |
     REST API powering the Traefik Manager web UI and official mobile app.
 

--- a/docs/tab-logs.md
+++ b/docs/tab-logs.md
@@ -49,6 +49,8 @@ accessLog:
   format: common
 ```
 
+Both the `common` (CLF text) and `json` access log formats are parsed into cards. Lines that match neither are shown as-is.
+
 Then point traefik-manager at the log file via the `ACCESS_LOG_PATH` environment variable (default: `/app/logs/access.log`).
 
 :::tabs

--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -11,6 +11,10 @@ The **Routes** tab (also called Services) is the main management interface. It d
 - Multi-domain routes show each domain as a separate pill badge; clicking a domain or target copies it to the clipboard
 - Full detail view via the info button - shows live Traefik status, service health, and raw config
 
+## Empty state
+
+When no routes exist yet - such as on a fresh install - the tab shows a prompt with an **Add Route** button instead of a blank grid. When a search or filter matches nothing, it shows a "No routes match your filters" message instead.
+
 ## Filtering
 
 The filter bar above the grid lets you narrow routes by:

--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -57,6 +57,12 @@ For TCP routes, enter a raw SNI rule (`HostSNI(\`*\`)` for passthrough). UDP rou
 
 Click the pencil icon on any route card, or open the detail panel and click **Edit**.
 
+Saving only rewrites the parts of the route the form owns: the rule, entry points, service reference, middlewares and TLS on the router, and the first server address, `passHostHeader` and the insecure-TLS transport on the service. Anything else you have written by hand is preserved - router `priority`, sticky sessions, health checks, additional servers, and your own `serversTransport`. An existing route also keeps the service name it already points at, rather than being renamed to `<name>-service`.
+
+::: warning Advanced service types
+If a router points at a `weighted`, `mirroring` or `failover` service instead of a `loadBalancer`, that service is left untouched, so editing the target field in the modal has no effect on it. Edit those services directly in the config file.
+:::
+
 ## Deleting a route
 
 Click the trash icon on the route card. The corresponding service entry in `dynamic.yml` is removed automatically.

--- a/static/openapi.yaml
+++ b/static/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Traefik Manager API
-  version: 1.7.2
+  version: 1.7.3
   description: |
     REST API powering the Traefik Manager web UI and official mobile app.
 

--- a/static/sw.js
+++ b/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'traefik-manager-v1.7.2';
+const CACHE_NAME = 'traefik-manager-v1.7.3';
 
 const STATIC_ASSETS = [];
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -5230,7 +5230,37 @@ const HTTP_STATUS = {
     500:'Internal Server Error',501:'Not Implemented',502:'Bad Gateway',503:'Service Unavailable',504:'Gateway Timeout'
 };
 
+function _fmtLogDuration(ns) {
+    if (!ns) return '';
+    if (ns >= 1e9) return (ns / 1e9).toFixed(2) + 's';
+    if (ns >= 1e6) return Math.round(ns / 1e6) + 'ms';
+    if (ns >= 1e3) return Math.round(ns / 1e3) + 'µs';
+    return ns + 'ns';
+}
+
 function parseLogLine(raw) {
+    const trimmed = raw.trimStart();
+    if (trimmed.startsWith('{')) {
+        try {
+            const j = JSON.parse(trimmed);
+            if (j.RequestMethod || j.RequestPath || j.DownstreamStatus) {
+                const durNs = typeof j.Duration === 'number' ? j.Duration : parseInt(j.Duration) || 0;
+                const size = j.DownstreamContentSize != null ? j.DownstreamContentSize : (j.OriginContentSize != null ? j.OriginContentSize : '');
+                return {
+                    ip: j.ClientHost || (j.ClientAddr || '').split(':')[0] || '',
+                    date: j.StartUTC || j.StartLocal || j.time || '',
+                    method: j.RequestMethod || '',
+                    path: j.RequestPath || '',
+                    status: parseInt(j.DownstreamStatus) || parseInt(j.OriginStatus) || 0,
+                    size: String(size),
+                    service: j.ServiceName || '',
+                    serviceUrl: j.ServiceURL || j.ServiceAddr || '',
+                    duration: _fmtLogDuration(durNs),
+                    raw
+                };
+            }
+        } catch (_) {}
+    }
     const full = raw.match(
         /^(\S+) \S+ \S+ \[([^\]]+)\] "(\S+) (\S+)[^"]*" (\d+) (\S+) "[^"]*" "[^"]*" \S+ "([^"]*)" "([^"]*)" (\S+)/
     );

--- a/templates/index.html
+++ b/templates/index.html
@@ -1372,9 +1372,8 @@ async function saveRouteAjax(event) {
         if (_activeAgent) fd.append('agent_id', _activeAgent.id);
         const res = await fetch(form.action, { method:'POST', headers:{'X-Requested-With':'fetch'}, body: fd });
         const json = await res.json();
-        closeModal();
         showToast(json.message, json.ok ? 'success' : 'error');
-        if (json.ok) { refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
+        if (json.ok) { closeModal(); refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
     } catch(e) {
         showToast('Error saving route', 'error');
     } finally {
@@ -1419,9 +1418,8 @@ async function saveMwAjax(event) {
         if (_activeAgent) fd.append('agent_id', _activeAgent.id);
         const res = await fetch(form.action, { method:'POST', headers:{'X-Requested-With':'fetch'}, body: fd });
         const json = await res.json();
-        closeMwModal();
         showToast(json.message, json.ok ? 'success' : 'error');
-        if (json.ok) { _cachedMiddlewares = null; refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
+        if (json.ok) { closeMwModal(); _cachedMiddlewares = null; refreshRoutes(); fetchNotifications(); if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData(); setTimeout(fetchNotifications, 8000); }
     } catch(e) {
         showToast('Error saving middleware', 'error');
     } finally {
@@ -2180,13 +2178,50 @@ function _onWildcardToggle(checked) {
     if (base) { mainEl.value = base; sansEl.value = '*.' + base; }
 }
 
+function _applyHttpRuleToForm(rule) {
+    const isSimpleRule = /^(Host\(`[^`]+`\)(\s*\|\|\s*Host\(`[^`]+`\))*)$/.test(rule.trim());
+    if (!isSimpleRule && rule) {
+        setHttpRuleMode('advanced');
+        document.getElementById('httpRule').value = rule;
+    } else {
+        setHttpRuleMode('simple');
+    }
+    _updateRouteModalForAgent();
+    const domainsForMatch = _domainsForForm();
+    let subdomain = '';
+    const hostMatches = [...rule.matchAll(/Host\(`([^`]+)`\)/g)].map(m => m[1]);
+    const matchedDomains = [];
+    for (let fullHost of hostMatches) {
+        let found = false;
+        for (let d of domainsForMatch) {
+            if (fullHost.endsWith('.' + d)) { if (!subdomain) subdomain = fullHost.slice(0, -(d.length + 1)); matchedDomains.push(d); found = true; break; }
+            else if (fullHost === d) { matchedDomains.push(d); found = true; break; }
+        }
+        if (!found && !subdomain) subdomain = fullHost;
+    }
+    document.getElementById('subdomain').value = subdomain;
+    if (document.getElementById('domainChips')) {
+        _initDomainChips(matchedDomains.length ? matchedDomains : []);
+    } else {
+        const sel = document.getElementById('domainSelect');
+        if (sel && matchedDomains.length > 0) sel.value = matchedDomains[0];
+    }
+}
+
 async function cloneRoute(btn) {
     const app = JSON.parse(btn.getAttribute('data-app'));
     await openModal();
     document.getElementById('modalTitle').innerText = 'Clone Route';
+    document.getElementById('serviceName').value = (app.name || '') + '-copy';
+    const cfSel = document.getElementById('configFileSelect');
+    if (app.configFile) {
+        document.getElementById('configFile').value = app.configFile;
+        if (cfSel) cfSel.value = app.configFile;
+    }
     const proto = app.protocol || 'http';
     setProtocol(proto);
     if (proto === 'http') {
+        _applyHttpRuleToForm(app.rule || '');
         const targetScheme = (app.target || '').startsWith('https://') ? 'https' : 'http';
         let target = (app.target || '').replace('http://','').replace('https://','');
         const parts = target.split(':');
@@ -2223,6 +2258,7 @@ async function cloneRoute(btn) {
             tlsOptSel.value = app.tlsOptionsProfile || '';
         }
     } else if (proto === 'tcp') {
+        document.getElementById('tcpRule').value = app.rule || '';
         const target = (app.target || '').split(':');
         document.getElementById('targetIpTcp').value = target[0] || '';
         document.getElementById('targetPortTcp').value = target[1] || '';
@@ -2293,34 +2329,7 @@ async function handleEdit(btn) {
     setProtocol(proto);
 
     if (proto === 'http') {
-        let rule = app.rule || '';
-        const isSimpleRule = /^(Host\(`[^`]+`\)(\s*\|\|\s*Host\(`[^`]+`\))*)$/.test(rule.trim());
-        if (!isSimpleRule && rule) {
-            setHttpRuleMode('advanced');
-            document.getElementById('httpRule').value = rule;
-        } else {
-            setHttpRuleMode('simple');
-        }
-        _updateRouteModalForAgent();
-        const domainsForMatch = _domainsForForm();
-        let subdomain = '';
-        const hostMatches = [...rule.matchAll(/Host\(`([^`]+)`\)/g)].map(m => m[1]);
-        const matchedDomains = [];
-        for (let fullHost of hostMatches) {
-            let found = false;
-            for (let d of domainsForMatch) {
-                if (fullHost.endsWith('.' + d)) { if (!subdomain) subdomain = fullHost.slice(0, -(d.length + 1)); matchedDomains.push(d); found = true; break; }
-                else if (fullHost === d) { matchedDomains.push(d); found = true; break; }
-            }
-            if (!found && !subdomain) subdomain = fullHost;
-        }
-        document.getElementById('subdomain').value = subdomain;
-        if (document.getElementById('domainChips')) {
-            _initDomainChips(matchedDomains.length ? matchedDomains : []);
-        } else {
-            const sel = document.getElementById('domainSelect');
-            if (sel && matchedDomains.length > 0) sel.value = matchedDomains[0];
-        }
+        _applyHttpRuleToForm(app.rule || '');
 
         const targetScheme = (app.target || '').startsWith('https://') ? 'https' : 'http';
         let target = app.target.replace('http://','').replace('https://','');
@@ -3022,15 +3031,24 @@ async function bulkDelete() {
     if (!ids.length) return;
     if (!await _confirm(`Delete ${ids.length} route${ids.length > 1 ? 's' : ''}?`, 'Bulk Delete', 'Delete')) return;
     const csrf = document.querySelector('meta[name="csrf-token"]')?.content || '';
+    let failed = 0;
     for (const id of ids) {
         const card = document.querySelector(`.route-card[data-routekey="${CSS.escape(id)}"]`);
         const cf   = card?.dataset.configfile || '';
         const data = new FormData();
         data.append('csrf_token', csrf);
         if (cf) data.append('configFile', cf);
-        await fetch('/delete/' + encodeURIComponent(id), { method:'POST', headers:{'X-Requested-With':'fetch'}, body: data });
+        if (_activeAgent) data.append('agent_id', _activeAgent.id);
+        try {
+            const res  = await fetch('/delete/' + encodeURIComponent(id), { method:'POST', headers:{'X-Requested-With':'fetch'}, body: data });
+            const json = await res.json();
+            if (!res.ok || !json.ok) failed++;
+        } catch(e) { failed++; }
     }
+    if (failed) showToast(`${failed} of ${ids.length} route${ids.length > 1 ? 's' : ''} could not be deleted.`, 'error');
+    else showToast(`Deleted ${ids.length} route${ids.length > 1 ? 's' : ''}.`, 'success');
     _bulkSelected.clear(); updateBulkBar(); refreshRoutes(); fetchNotifications();
+    if (typeof window.rmInvalidateData === 'function') window.rmInvalidateData();
 }
 let _mwViewMode = 'grid';
 let _allMiddlewares = {{ middlewares | tojson | safe }};

--- a/templates/index.html
+++ b/templates/index.html
@@ -2033,7 +2033,7 @@ function _customDomainPrompt(btn) {
     };
     input.addEventListener('keydown', e => {
         if (e.key === 'Enter') { e.preventDefault(); commit(); }
-        else if (e.key === 'Escape') { if (window._domainChipRender) window._domainChipRender(); }
+        else if (e.key === 'Escape' && input.value) { e.stopPropagation(); input.value = ''; if (window._domainChipRender) window._domainChipRender(); }
     });
     input.addEventListener('blur', () => { if (input.isConnected) commit(); });
 }
@@ -3641,8 +3641,28 @@ function _isTyping() {
     return t === 'INPUT' || t === 'TEXTAREA' || t === 'SELECT' || document.activeElement?.isContentEditable;
 }
 
+function _closeTopModal() {
+    const modals = [
+        ['tlsOptionsModal', closeTlsOptionModal],
+        ['appModal', closeModal],
+        ['mwModal', closeMwModal],
+        ['settingsModal', closeSettingsModal],
+        ['rmEditModal', window.rmCloseEditModal],
+        ['rmGroupsModal', window.rmCloseGroupsModal],
+    ];
+    for (const [id, close] of modals) {
+        const el = document.getElementById(id);
+        if (el && getComputedStyle(el).display !== 'none' && typeof close === 'function') {
+            close();
+            return true;
+        }
+    }
+    return false;
+}
+
 document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
+        if (_closeTopModal()) return;
         closeRouteDetail();
         closeMwDetail();
         closeSvcDetail();

--- a/templates/index.html
+++ b/templates/index.html
@@ -841,6 +841,7 @@ function pickRouteDomain(val, label) {
 
 function filterRoutes() {
     const q = document.getElementById('searchRoutes').value.toLowerCase();
+    let visible = 0;
     for (const card of _routeCardEls) {
         const name    = card.dataset.name || '';
         const proto   = card.dataset.protocol || '';
@@ -852,6 +853,21 @@ function filterRoutes() {
             (!currentRouteDomainFilter || domains.some(d => d === currentRouteDomainFilter || d.endsWith('.' + currentRouteDomainFilter))) &&
             (currentRouteStatusFilter === 'all' || (currentRouteStatusFilter === 'active' && enabled) || (currentRouteStatusFilter === 'inactive' && !enabled));
         card.style.display = show ? '' : 'none';
+        if (show) visible++;
+    }
+    const emptyEl = document.getElementById('routeEmpty');
+    if (emptyEl && _routeCardEls.length > 0) {
+        if (visible === 0) {
+            const t = document.getElementById('routeEmptyText');
+            const sub = document.getElementById('routeEmptySub');
+            const cta = document.getElementById('routeEmptyCta');
+            if (t) t.textContent = 'No routes match your filters';
+            if (sub) sub.style.display = 'none';
+            if (cta) cta.style.display = 'none';
+            emptyEl.style.display = '';
+        } else {
+            emptyEl.style.display = 'none';
+        }
     }
 }
 
@@ -1736,7 +1752,16 @@ function renderRouteGrid(apps) {
     if (apps.length === 0) {
         grid.className = 'grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4';
         grid.innerHTML = '';
-        if (emptyEl) emptyEl.style.display = '';
+        _routeCardEls = [];
+        if (emptyEl) {
+            const t = document.getElementById('routeEmptyText');
+            const sub = document.getElementById('routeEmptySub');
+            const cta = document.getElementById('routeEmptyCta');
+            if (t) t.textContent = _activeAgent ? 'No routes on this server yet' : 'No routes yet';
+            if (sub) sub.style.display = '';
+            if (cta) cta.style.display = 'inline-flex';
+            emptyEl.style.display = '';
+        }
         return;
     }
     if (emptyEl) emptyEl.style.display = 'none';

--- a/templates/index.html
+++ b/templates/index.html
@@ -2385,6 +2385,7 @@ async function handleEdit(btn) {
             if (sansEl) sansEl.value = (first.sans || []).join('\n');
         } else if (wChk) {
             wChk.checked = false;
+            _onWildcardToggle(false);
         }
         const tlsOptSel2 = document.getElementById('tlsOptionsProfileSelect');
         if (tlsOptSel2) {

--- a/templates/tabs/tab_services.html
+++ b/templates/tabs/tab_services.html
@@ -61,4 +61,13 @@
     <div id="configErrorBanner" style="display:none;background:rgba(234,179,8,0.08);border:1px solid rgba(234,179,8,0.3);border-radius:10px;padding:12px 16px;margin-bottom:16px"></div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4" id="routeGrid"></div>
+
+    <div id="routeEmpty" class="text-center py-20" style="display:none;color:var(--muted)">
+        <i class="ph-light ph-list-plus text-6xl block mb-4 opacity-30"></i>
+        <p class="text-base font-medium" id="routeEmptyText">No routes yet</p>
+        <p class="text-sm mt-1 mb-5" id="routeEmptySub">Create your first route to start managing your Traefik proxy.</p>
+        <button onclick="openModal()" id="routeEmptyCta" class="nav-btn nav-btn-primary" style="display:inline-flex">
+            <i class="ph-bold ph-plus"></i> Add Route
+        </button>
+    </div>
 </div>


### PR DESCRIPTION
## Summary

The "Request wildcard certificate" checkbox has no `name`, so it is never submitted — the hidden `tlsWildcardMain` / `tlsWildcardSans` inputs are the only source of the `tls.domains` block the backend writes whenever TLS is enabled. `handleEdit` only *unchecked* the box when editing a route without a wildcard cert; it never cleared those hidden inputs. So after editing a route that has a wildcard cert, opening and saving a different route (that uses a resolver but no wildcard) silently wrote the first route's wildcard domains onto it — requesting/serving the wrong certificate, with no visible warning.

The fix clears the two hidden inputs in that branch (via `_onWildcardToggle(false)`), exactly as `openModal` already does.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing

Scenarios verified:
- Edit a route *with* a wildcard cert: domains still load and save correctly.
- Edit route A (wildcard) → cancel → edit route B (resolver, no wildcard) → save: B no longer gains A's `tls.domains`.
- Add-new and clone flows unaffected (both go through `openModal`).

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] PR targets the `dev` branch (never `main`)
- [ ] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in