### PR TITLE
fix: don't apply another route's wildcard cert domains when editing

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2385,6 +2385,7 @@ async function handleEdit(btn) {
             if (sansEl) sansEl.value = (first.sans || []).join('\n');
         } else if (wChk) {
             wChk.checked = false;
+            _onWildcardToggle(false);
         }
         const tlsOptSel2 = document.getElementById('tlsOptionsProfileSelect');
         if (tlsOptSel2) {


### PR DESCRIPTION
## Summary

The "Request wildcard certificate" checkbox has no `name`, so it is never submitted — the hidden `tlsWildcardMain` / `tlsWildcardSans` inputs are the only source of the `tls.domains` block the backend writes whenever TLS is enabled. `handleEdit` only *unchecked* the box when editing a route without a wildcard cert; it never cleared those hidden inputs. So after editing a route that has a wildcard cert, opening and saving a different route (that uses a resolver but no wildcard) silently wrote the first route's wildcard domains onto it — requesting/serving the wrong certificate, with no visible warning.

The fix clears the two hidden inputs in that branch (via `_onWildcardToggle(false)`), exactly as `openModal` already does.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Docs update
- [ ] Refactor / cleanup

## Testing

Scenarios verified:
- Edit a route *with* a wildcard cert: domains still load and save correctly.
- Edit route A (wildcard) → cancel → edit route B (resolver, no wildcard) → save: B no longer gains A's `tls.domains`.
- Add-new and clone flows unaffected (both go through `openModal`).

- [x] Tested with a real Traefik instance
- [x] Tested the affected tab/feature end-to-end

## Checklist

- [x] PR targets the `dev` branch (never `main`)
- [ ] Updated relevant docs in `docs/` if behaviour changed
- [x] No commented-out code or debug statements left in