### PR TITLE
Client IP diagnostic + source-IP classification

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ import logging
 import threading
 import subprocess
 import fcntl
+import ipaddress
 import contextlib
 import requests
 import urllib3
@@ -37,7 +38,8 @@ logger = logging.getLogger("traefik-manager")
 
 
 app = Flask(__name__)
-app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1)
+PROXY_FIX_HOPS = 1
+app.wsgi_app = ProxyFix(app.wsgi_app, x_for=PROXY_FIX_HOPS, x_proto=1, x_host=1)
 
 _CONFIG_DIR      = os.path.dirname(os.environ.get('SETTINGS_PATH', '/app/config/manager.yml'))
 _SECRET_KEY_PATH = os.path.join(_CONFIG_DIR, '.secret_key')
@@ -3993,6 +3995,52 @@ def api_geoip_update():
         add_notification('success', f'GeoIP database updated (DB-IP {info})')
         return jsonify({'success': True, 'db_month': info, 'status': _geoip_status()})
     return jsonify({'success': False, 'error': f'Download failed: {info}'}), 502
+
+
+_CGNAT_NETWORK = ipaddress.ip_network('100.64.0.0/10')
+
+def _classify_ip(ip: str) -> str:
+    try:
+        addr = ipaddress.ip_address((ip or '').strip())
+    except ValueError:
+        return 'unknown'
+    if addr.is_loopback:
+        return 'loopback'
+    if addr.is_link_local:
+        return 'link-local'
+    if addr.version == 4 and addr in _CGNAT_NETWORK:
+        return 'cgnat'
+    if addr.is_private:
+        return 'private'
+    return 'public'
+
+
+@app.route('/api/diagnostics/client-ip')
+@login_required
+def api_client_ip_diagnostic():
+    orig        = request.environ.get('werkzeug.proxy_fix.orig') or {}
+    socket_peer = orig.get('REMOTE_ADDR', '') or ''
+    headers     = {
+        'X-Forwarded-For':   request.headers.get('X-Forwarded-For', ''),
+        'X-Real-IP':         request.headers.get('X-Real-IP', ''),
+        'CF-Connecting-IP':  request.headers.get('CF-Connecting-IP', ''),
+        'X-Forwarded-Proto': request.headers.get('X-Forwarded-Proto', ''),
+        'X-Forwarded-Host':  request.headers.get('X-Forwarded-Host', ''),
+    }
+    xff_chain = [p.strip() for p in headers['X-Forwarded-For'].split(',') if p.strip()]
+    effective = request.remote_addr or ''
+    seen      = [ip for ip in [effective, socket_peer, *xff_chain] if ip]
+    classes   = {ip: _classify_ip(ip) for ip in seen}
+    return jsonify({
+        'effective_ip':        effective,
+        'effective_class':     _classify_ip(effective),
+        'socket_peer':         socket_peer,
+        'socket_peer_class':   _classify_ip(socket_peer),
+        'headers':             headers,
+        'forwarded_for_chain': xff_chain,
+        'proxy_hops':          PROXY_FIX_HOPS,
+        'classes':             classes,
+    })
 
 
 @app.route('/api/settings/backup-retention', methods=['POST'])

--- a/docs/api.md
+++ b/docs/api.md
@@ -253,6 +253,31 @@ Tail Traefik access logs. Requires `ACCESS_LOG_PATH`.
 
 ---
 
+### `GET /api/diagnostics/client-ip`
+
+Read-only diagnostic for the current request. Returns what the app sees as the client after `ProxyFix`, the raw socket peer, the forwarding headers as received, the number of trusted proxy hops, and a scope classification (`public`, `private`, `cgnat`, `loopback`, `link-local` or `unknown`) for each observed IP.
+
+```json
+{
+  "effective_ip": "203.0.113.5",
+  "effective_class": "public",
+  "socket_peer": "172.20.0.1",
+  "socket_peer_class": "private",
+  "headers": {
+    "X-Forwarded-For": "203.0.113.5",
+    "X-Real-IP": "",
+    "CF-Connecting-IP": "",
+    "X-Forwarded-Proto": "https",
+    "X-Forwarded-Host": "example.com"
+  },
+  "forwarded_for_chain": ["203.0.113.5"],
+  "proxy_hops": 1,
+  "classes": { "203.0.113.5": "public", "172.20.0.1": "private" }
+}
+```
+
+---
+
 ## Dashboard
 
 ### `GET /api/dashboard/config`

--- a/docs/tab-logs.md
+++ b/docs/tab-logs.md
@@ -12,7 +12,7 @@ Above the log list, an analytics panel summarises the currently loaded entries a
 - **Methods** - breakdown of HTTP verbs (GET, POST, PUT, DELETE, PATCH, etc.) with bar charts
 
 **Row 2 - Top lists**
-- **Top IPs** - the 6 client IPs with the most requests
+- **Top IPs** - the 6 client IPs with the most requests, each tagged with its scope (**Public**, **Private**, **CGNAT**, **Loopback** or **Link-local**) so local noise - such as a gateway's `192.168.x.1` from hairpin NAT - is easy to tell apart from real public clients
 - **Top Paths** - the 6 most frequently requested paths
 - **Top Services** - the 6 Traefik services that handled the most requests
 
@@ -94,6 +94,19 @@ usermod -aG adm traefik-manager
 ## Geolocation
 
 When [IP geolocation](geoip.md) is enabled (**Settings → Interface → Geolocation**), the Logs tab adds a country flag next to each client IP, a **Top Countries** breakdown, and a shaded **world map** of where the requests came from. Click a country on the map or in the list to filter the log entries to it. Lookups run on the server against a local database, so no IP addresses are sent to any third party.
+
+## Client IP diagnostic
+
+The **network** icon in the top navigation bar opens a read-only **Client IP Diagnostic** for your own request. It shows:
+
+- **App sees (client)** - the IP traefik-manager treats as the client after `ProxyFix`. This is the address that feeds the login/audit log, and the one your `ipAllowList` and CrowdSec rules match against.
+- **Socket peer** - the IP on the other end of the raw TCP connection (your reverse proxy, or the real client if there is none).
+- **Trusted hops** - how many proxy hops the app trusts when reading `X-Forwarded-For`.
+- **Forwarding headers** - the raw `X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`, `X-Forwarded-Proto` and `X-Forwarded-Host` values as received.
+
+Each IP is tagged with the same scope classification as the Top IPs list. If the client IP the app trusts is private, loopback or CGNAT while you expect public clients, the panel warns you - that usually means the upstream proxy's `trustedIPs` or the trusted-hop count is off, and the real client IP is being lost before it reaches logs, CrowdSec and `ipAllowList`.
+
+For hairpin-NAT'd LAN traffic the real client IP is already gone at the network layer, so it cannot be recovered here - the panel only reports what actually arrives.
 
 ## Notes
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -109,6 +109,12 @@ main { overflow-x: hidden; }
 .badge-red  { background: rgba(248,81,73,0.15); color: var(--red); border: 1px solid rgba(248,81,73,0.3); }
 .badge-muted { background: rgba(139,148,158,0.1); color: var(--muted); border: 1px solid rgba(139,148,158,0.3); }
 
+.ip-badge { display: inline-flex; align-items: center; flex-shrink: 0; padding: 1px 6px; border-radius: 6px; font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; line-height: 1.5; }
+.ip-badge-public  { background: rgba(36,161,222,0.15); color: var(--blue); }
+.ip-badge-private { background: rgba(210,153,34,0.15); color: var(--yellow); }
+.ip-badge-cgnat   { background: rgba(240,136,62,0.15); color: var(--orange); }
+.ip-badge-muted   { background: rgba(139,148,158,0.12); color: var(--muted); }
+
 .status-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
 .status-online  { background: var(--green); box-shadow: 0 0 6px rgba(63,185,80,0.6); }
 .status-offline { background: var(--red); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -422,6 +422,8 @@
 
 {% include 'modals/tls_options_modal.html' %}
 
+{% include 'modals/ip_diagnostic_modal.html' %}
+
 {% include 'modals/detail_panels.html' %}
 
 <script>
@@ -3666,6 +3668,7 @@ function _closeTopModal() {
         ['appModal', closeModal],
         ['mwModal', closeMwModal],
         ['settingsModal', closeSettingsModal],
+        ['ipDiagModal', closeIpDiagModal],
         ['rmEditModal', window.rmCloseEditModal],
         ['rmGroupsModal', window.rmCloseGroupsModal],
     ];
@@ -5277,6 +5280,99 @@ function _fmtLogDuration(ns) {
     return ns + 'ns';
 }
 
+function classifyIp(ip) {
+    if (!ip) return 'unknown';
+    ip = ip.trim();
+    const v4 = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (v4) {
+        const o = v4.slice(1).map(Number);
+        if (o.some(n => n > 255)) return 'unknown';
+        const [a, b] = o;
+        if (a === 127) return 'loopback';
+        if (a === 169 && b === 254) return 'link-local';
+        if (a === 10) return 'private';
+        if (a === 172 && b >= 16 && b <= 31) return 'private';
+        if (a === 192 && b === 168) return 'private';
+        if (a === 100 && b >= 64 && b <= 127) return 'cgnat';
+        return 'public';
+    }
+    let v6 = ip.replace(/^\[|\]$/g, '').split('%')[0].toLowerCase();
+    if (!v6.includes(':')) return 'unknown';
+    if (v6 === '::1') return 'loopback';
+    if (v6.startsWith('fe80')) return 'link-local';
+    if (v6.startsWith('fc') || v6.startsWith('fd')) return 'private';
+    if (v6.startsWith('::ffff:') && v6.slice(7).includes('.')) return classifyIp(v6.slice(7));
+    return 'public';
+}
+
+const _IP_CLASS_META = {
+    'public':     ['Public', 'ip-badge-public'],
+    'private':    ['Private', 'ip-badge-private'],
+    'cgnat':      ['CGNAT', 'ip-badge-cgnat'],
+    'loopback':   ['Loopback', 'ip-badge-muted'],
+    'link-local': ['Link-local', 'ip-badge-muted'],
+    'unknown':    ['?', 'ip-badge-muted'],
+};
+
+function ipClassBadge(cls) {
+    const [label, klass] = _IP_CLASS_META[cls] || _IP_CLASS_META['unknown'];
+    return `<span class="ip-badge ${klass}">${label}</span>`;
+}
+
+function openIpDiagModal() {
+    const m = document.getElementById('ipDiagModal');
+    if (!m) return;
+    m.style.display = 'flex';
+    loadIpDiagnostic();
+}
+
+function closeIpDiagModal() {
+    const m = document.getElementById('ipDiagModal');
+    if (m) m.style.display = 'none';
+}
+
+async function loadIpDiagnostic() {
+    const body = document.getElementById('ipDiagBody');
+    if (!body) return;
+    body.innerHTML = `<div class="text-xs py-4 text-center" style="color:var(--muted)">Loading...</div>`;
+    let d;
+    try {
+        d = await fetch('/api/diagnostics/client-ip').then(r => r.json());
+    } catch (_) {
+        body.innerHTML = `<div class="text-xs py-4 text-center" style="color:var(--red)">Failed to load diagnostic.</div>`;
+        return;
+    }
+    const row = (label, ip, cls, hint) => `
+        <div class="flex items-center gap-2 py-2" style="border-bottom:1px solid var(--border)">
+            <span class="text-xs" style="color:var(--muted);min-width:120px">${label}</span>
+            <span class="text-xs font-mono truncate" style="color:var(--text);flex:1;min-width:0" title="${_esc(ip || '')}">${ip ? _esc(ip) : '<span style="color:var(--muted)">—</span>'}</span>
+            ${ip ? ipClassBadge(cls || classifyIp(ip)) : ''}
+        </div>` + (hint ? `<div class="text-xs" style="color:var(--muted);margin:-4px 0 4px 122px">${hint}</div>` : '');
+
+    const hdrRows = Object.entries(d.headers || {}).map(([k, v]) => `
+        <div class="flex items-center gap-2 py-1.5" style="border-bottom:1px solid var(--border)">
+            <span class="text-xs font-mono" style="color:var(--muted);min-width:120px">${_esc(k)}</span>
+            <span class="text-xs font-mono truncate" style="color:${v ? 'var(--text)' : 'var(--muted)'};flex:1;min-width:0" title="${_esc(v || '')}">${v ? _esc(v) : 'not set'}</span>
+        </div>`).join('');
+
+    const spoofable = d.effective_class === 'private' || d.effective_class === 'loopback' || d.effective_class === 'cgnat';
+
+    body.innerHTML = `
+        <div class="rounded-xl p-3 mb-3" style="background:var(--card);border:1px solid var(--border)">
+            ${row('App sees (client)', d.effective_ip, d.effective_class)}
+            ${row('Socket peer', d.socket_peer, d.socket_peer_class, 'The direct TCP connection — your reverse proxy, or the real client if none.')}
+            <div class="flex items-center gap-2 py-2">
+                <span class="text-xs" style="color:var(--muted);min-width:120px">Trusted hops</span>
+                <span class="text-xs font-mono" style="color:var(--text)">${d.proxy_hops}</span>
+            </div>
+        </div>
+        <div class="text-xs font-semibold uppercase tracking-wide mb-2" style="color:var(--muted)">Forwarding Headers</div>
+        <div class="rounded-xl p-3 mb-3" style="background:var(--card);border:1px solid var(--border)">
+            ${hdrRows}
+        </div>
+        ${spoofable ? `<div class="rounded-xl p-3 text-xs" style="background:rgba(210,153,34,0.1);border:1px solid rgba(210,153,34,0.3);color:var(--text)"><i class="ph-bold ph-warning" style="color:var(--yellow);margin-right:6px"></i>The client IP the app trusts is <strong>${_esc(d.effective_class)}</strong>. If clients should reach you from the public internet, a proxy in front is rewriting it — check that your trusted hops and the upstream <code class="font-mono">trustedIPs</code> are set correctly, or real client IPs will be lost to logs, CrowdSec and ipAllowList.</div>` : ''}`;
+}
+
 function parseLogLine(raw) {
     const trimmed = raw.trimStart();
     if (trimmed.startsWith('{')) {
@@ -5353,12 +5449,13 @@ function renderLogStats(entries) {
     const methods  = topN('method', 6);
 
     const hbar = (v, max, col) => `<div style="flex:1;height:6px;border-radius:3px;background:var(--input-bg);overflow:hidden"><div style="height:100%;border-radius:3px;background:${col};width:${max?Math.max(3,Math.round((v/max)*100)):0}%"></div></div>`;
-    const topList = (pairs, col='var(--blue)', strip=false) => {
+    const topList = (pairs, col='var(--blue)', strip=false, decorate=null) => {
         const max = pairs[0]?.[1]||1;
         return pairs.map(([k,v]) => {
             const label = strip ? k.replace(/@docker|@file|@kubernetes/g,'') : k;
             return `<div class="flex items-center gap-2 py-1" style="border-bottom:1px solid var(--border)">
                 <span class="text-xs font-mono truncate" style="color:var(--text);min-width:0;flex:1" title="${_esc(k)}">${_esc(label)}</span>
+                ${decorate ? decorate(k) : ''}
                 ${hbar(v, max, col)}
                 <span class="text-xs font-bold flex-shrink-0 tabular-nums" style="color:var(--muted);min-width:28px;text-align:right">${v}</span>
             </div>`;
@@ -5417,7 +5514,7 @@ function renderLogStats(entries) {
     <div class="grid gap-3 grid-cols-1 sm:grid-cols-3">
         <div class="rounded-xl p-4" style="background:var(--card);border:1px solid var(--border)">
             <div class="text-xs font-semibold uppercase tracking-wide mb-2" style="color:var(--muted)">Top IPs</div>
-            ${topList(topIps, 'var(--blue)')}
+            ${topList(topIps, 'var(--blue)', false, ip => ipClassBadge(classifyIp(ip)))}
         </div>
         <div class="rounded-xl p-4" style="background:var(--card);border:1px solid var(--border)">
             <div class="text-xs font-semibold uppercase tracking-wide mb-2" style="color:var(--muted)">Top Paths</div>

--- a/templates/modals/ip_diagnostic_modal.html
+++ b/templates/modals/ip_diagnostic_modal.html
@@ -1,0 +1,21 @@
+<div id="ipDiagModal" class="modal-overlay" style="display:none" onclick="_onBackdropClick(event, closeIpDiagModal)">
+    <div class="modal-box" style="max-width:560px">
+        <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border)">
+            <div class="flex items-center gap-2">
+                <i class="ph-bold ph-network" style="color:var(--blue)"></i>
+                <h3 class="font-bold text-sm" style="color:var(--text)">Client IP Diagnostic</h3>
+            </div>
+            <button type="button" onclick="closeIpDiagModal()" class="btn-icon"><i class="ph-bold ph-x text-sm"></i></button>
+        </div>
+
+        <div class="px-5 py-4 space-y-4" style="max-height:70vh;overflow-y:auto">
+            <p class="text-xs" style="color:var(--muted)">What this instance sees for your own request right now. Use it to check whether the real client IP is reaching the app before it feeds logs, CrowdSec and <code class="font-mono">ipAllowList</code>.</p>
+            <div id="ipDiagBody"></div>
+        </div>
+
+        <div class="flex justify-end gap-2 px-5 py-4" style="border-top:1px solid var(--border)">
+            <button type="button" onclick="loadIpDiagnostic()" class="btn-secondary"><i class="ph-bold ph-arrows-clockwise text-xs" style="margin-right:6px"></i>Refresh</button>
+            <button type="button" onclick="closeIpDiagModal()" class="btn-primary">Close</button>
+        </div>
+    </div>
+</div>

--- a/templates/sections/mobile_menu.html
+++ b/templates/sections/mobile_menu.html
@@ -28,6 +28,9 @@
         <i class="ph-bold ph-device-mobile" style="color:var(--green)"></i> Install as App
     </button>
     <div class="mobile-menu-divider"></div>
+    <button onclick="openIpDiagModal(); closeMobileMenu()" class="mobile-menu-item">
+        <i class="ph-bold ph-network" style="color:var(--muted)"></i> Client IP Diagnostic
+    </button>
     <button onclick="openSettingsModal(); closeMobileMenu()" class="mobile-menu-item">
         <i class="ph-bold ph-gear" style="color:var(--muted)"></i> Settings
     </button>

--- a/templates/sections/navbar.html
+++ b/templates/sections/navbar.html
@@ -53,6 +53,9 @@
                     <i class="ph-bold ph-sun tm-theme-icon" data-pref="light"></i>
                     <i class="ph-bold ph-desktop tm-theme-icon" data-pref="system"></i>
                 </button>
+                <button onclick="openIpDiagModal()" class="nav-btn" title="Client IP diagnostic">
+                    <i class="ph-bold ph-network"></i>
+                </button>
                 <button onclick="openSettingsModal()" class="nav-btn" title="Settings">
                     <i class="ph-bold ph-gear"></i>
                 </button>


### PR DESCRIPTION
First of the focused pieces from #112, in the sequence we agreed on there (read-only diagnostic + source-IP classification first — highest value, zero risk).

## What's in it

**Client IP Diagnostic** — a read-only tool in the top nav (`network` icon; also in the mobile menu) that shows what this instance sees for *your own* request:
- **App sees (client)** — the IP trusted after `ProxyFix`, i.e. what feeds the login/audit log, `ipAllowList` and CrowdSec
- **Socket peer** — the raw TCP peer (your proxy, or the real client if none)
- **Trusted hops** and the raw forwarding headers (`X-Forwarded-For`, `X-Real-IP`, `CF-Connecting-IP`, `X-Forwarded-Proto`/`Host`) as received

Each IP is tagged with a scope classification. If the trusted client IP is private/loopback/CGNAT while public clients are expected, it warns that the upstream `trustedIPs`/hop count is likely off and real client IPs are being lost. It stays honest about hairpin-NAT'd LAN traffic — that IP is gone at L3 and is labelled, not "fixed".

Backed by a new read-only endpoint `GET /api/diagnostics/client-ip` (`@login_required`, no mutation).

**Top IPs classification** — the log-stats *Top IPs* card now tags each IP as Public / Private / CGNAT / Loopback / Link-local, so local noise (e.g. a UniFi gateway's `192.168.1.1` from hairpin NAT showing up as the top "client") is easy to tell apart from real public clients.

## Notes
- Classification uses Python's `ipaddress` on the backend and a mirrored classifier in JS for the client-side Top IPs render; both agree on the boundaries (incl. CGNAT `100.64.0.0/10`).
- `ProxyFix`'s hop count is now a single `PROXY_FIX_HOPS` constant, reported by the diagnostic — sets up the configurable-hop-count piece later.
- Docs updated: Logs tab page + API reference.

No config is written by any of this.