### PR TITLE
ipStrategy builder for the IP Allow List wizard

### DIFF
--- a/docs/tab-middlewares.md
+++ b/docs/tab-middlewares.md
@@ -41,6 +41,8 @@ Every template switches to **Wizard** mode - a structured form with labeled fiel
 
 The Forward Auth wizards (including Authentik, Authelia, and Gatekeeper) expose an optional **Max Response Body Size** field (`maxResponseBodySize`, Traefik 3.7+) to cap the auth server's response. See [Traefik Security Hardening](hardening.md) for the recommended hardening middlewares and options.
 
+The **IP Allow List** wizard includes a **Client IP source** (`ipStrategy`) selector. When Traefik is exposed directly, leave it on **Direct connection**. When a reverse proxy (Cloudflare, another Traefik, nginx) sits in front, the allow-list would otherwise match the proxy's IP on every request - pick **trusted hop depth** to set `ipStrategy.depth` (the number of proxies in front), or **exclude proxy IPs** to set `ipStrategy.excludedIPs` when the proxy's own addresses vary. Depth and excluded IPs are mutually exclusive, matching Traefik's own constraint.
+
 ### Middleware ordering in routes
 
 When attaching middlewares to a route, order matters - Traefik processes them left to right. The middleware chip selector in the route form shows selected middlewares first (numbered by position) with a divider before unselected ones, so you can see the processing order at a glance.

--- a/templates/index.html
+++ b/templates/index.html
@@ -1099,6 +1099,14 @@ const _wizKeyMap = {
     ipAllowListPrivate: 'ipAllowList',
 };
 
+function _wizIpStrategySync() {
+    const mode = document.getElementById('wizIpStrategy')?.value || 'direct';
+    const depthRow = document.getElementById('wizIpDepthRow');
+    const exRow    = document.getElementById('wizIpExcludedRow');
+    if (depthRow) depthRow.style.display = mode === 'depth' ? '' : 'none';
+    if (exRow)    exRow.style.display    = mode === 'excluded' ? '' : 'none';
+}
+
 function _showMwWizard(tpl) {
     document.querySelectorAll('.mw-wiz-form').forEach(el => el.style.display = 'none');
     const none = document.getElementById('mwWiz-none');
@@ -1109,6 +1117,13 @@ function _showMwWizard(tpl) {
         sec.style.display = '';
         sec.querySelectorAll('input:not([type=checkbox]):not([type=radio]), textarea').forEach(el => { el.value = ''; });
         sec.querySelectorAll('input[type=checkbox]').forEach(el => { el.checked = el.defaultChecked; });
+    }
+    if (key === 'ipAllowList') {
+        const strat = document.getElementById('wizIpStrategy');
+        if (strat) strat.value = 'direct';
+        const depth = document.getElementById('wizIpDepth');
+        if (depth) depth.value = '1';
+        _wizIpStrategySync();
     }
     if (tpl === 'forwardAuthAuthentik') {
         const el = document.getElementById('wizFaAddress'); if (el) el.value = 'http://authentik-server:9000/outpost.goauthentik.io/auth/traefik';
@@ -1200,6 +1215,14 @@ function buildYamlFromWizard() {
     } else if (key === 'ipAllowList') {
         const cidrs = _lines('wizIpCidrs');
         yaml = 'ipAllowList:\n  sourceRange:\n' + cidrs.map(c => '    - "' + c + '"').join('\n');
+        const strat = _val('wizIpStrategy', 'direct');
+        if (strat === 'depth') {
+            const depth = _val('wizIpDepth', '1');
+            yaml += '\n  ipStrategy:\n    depth: ' + (/^\d+$/.test(depth) && +depth > 0 ? depth : '1');
+        } else if (strat === 'excluded') {
+            const excluded = _lines('wizIpExcluded');
+            if (excluded.length) yaml += '\n  ipStrategy:\n    excludedIPs:\n' + excluded.map(c => '      - "' + c + '"').join('\n');
+        }
 
     } else if (key === 'secureHeaders') {
         const lines = ['headers:'];

--- a/templates/modals/mw_modal.html
+++ b/templates/modals/mw_modal.html
@@ -234,6 +234,25 @@ X-Forwarded-Name: name</textarea>
                             <label>Allowed CIDRs <span class="text-xs font-normal" style="color:var(--muted)">(one per line)</span></label>
                             <textarea id="wizIpCidrs" class="input-field font-mono text-sm" rows="5" placeholder="192.168.1.0/24&#10;10.0.0.0/8&#10;127.0.0.1/32"></textarea>
                         </div>
+                        <div>
+                            <label>Client IP source <span class="text-xs font-normal" style="color:var(--muted)">(ipStrategy)</span></label>
+                            <select id="wizIpStrategy" class="input-field" onchange="_wizIpStrategySync()">
+                                <option value="direct">Direct connection - Traefik is exposed directly</option>
+                                <option value="depth">Behind proxies - trusted hop depth</option>
+                                <option value="excluded">Behind proxies - exclude proxy IPs</option>
+                            </select>
+                            <p class="text-xs mt-1" style="color:var(--muted)">If a reverse proxy (Cloudflare, another Traefik, nginx) sits in front, the list must read the real client IP from <code class="font-mono">X-Forwarded-For</code> instead of the proxy's connection IP - otherwise every request looks like it comes from the proxy.</p>
+                        </div>
+                        <div id="wizIpDepthRow" style="display:none">
+                            <label>Trusted hop depth</label>
+                            <input type="number" id="wizIpDepth" class="input-field" value="1" min="1" style="width:120px">
+                            <p class="text-xs mt-1" style="color:var(--muted)">Number of trusted proxies in front of Traefik. It takes the IP that many positions from the right of <code class="font-mono">X-Forwarded-For</code>. One proxy (e.g. Cloudflare only) = <code class="font-mono">1</code>.</p>
+                        </div>
+                        <div id="wizIpExcludedRow" style="display:none">
+                            <label>Proxy IPs to exclude <span class="text-xs font-normal" style="color:var(--muted)">(one per line)</span></label>
+                            <textarea id="wizIpExcluded" class="input-field font-mono text-sm" rows="3" placeholder="173.245.48.0/20&#10;103.21.244.0/22"></textarea>
+                            <p class="text-xs mt-1" style="color:var(--muted)">Traefik strips these from the right of <code class="font-mono">X-Forwarded-For</code> and uses the next IP. Use when the proxy's own IPs vary. Cannot be combined with a fixed depth.</p>
+                        </div>
                     </div>
 
                     <div id="mwWiz-secureHeaders" class="mw-wiz-form space-y-3" style="display:none">


### PR DESCRIPTION
Second focused piece from #112 (the per-route `ipAllowList` generator you greenlit). Independent of #113.

## What's in it

The **IP Allow List** wizard gains a **Client IP source** (`ipStrategy`) selector, so the list can match the real client IP when Traefik sits behind a reverse proxy instead of allow-listing the proxy on every request:

- **Direct connection** (default) — no `ipStrategy`, match the connection IP (Traefik exposed directly)
- **Trusted hop depth** — writes `ipStrategy.depth` (the number of trusted proxies in front)
- **Exclude proxy IPs** — writes `ipStrategy.excludedIPs` for when the proxy's own addresses vary

Depth and excludedIPs are kept **mutually exclusive**, matching Traefik's own constraint. The selector resets to *Direct* on template switch and applies to both **IP Allow List** and **IP Allow List (Private Ranges)** (they share the wizard form via `_wizKeyMap`).

## Scope / safety
- Pure frontend wizard change — no backend, no new endpoint, no config written except the middleware you save through the normal `/save-middleware` path.
- Generated YAML validated for all three modes (direct / depth / excluded) — parses to valid Traefik `ipAllowList` structure with correct indentation and the exactly-one-of depth/excludedIPs invariant.
- Docs: Middlewares tab page updated.