### PR TITLE
Configurable ProxyFix trusted-hop count

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,8 +37,14 @@ logging.basicConfig(
 logger = logging.getLogger("traefik-manager")
 
 
+def _proxy_fix_hops() -> int:
+    try:
+        return max(0, int(os.environ.get('PROXY_FIX_HOPS', '1')))
+    except ValueError:
+        return 1
+
 app = Flask(__name__)
-PROXY_FIX_HOPS = 1
+PROXY_FIX_HOPS = _proxy_fix_hops()
 app.wsgi_app = ProxyFix(app.wsgi_app, x_for=PROXY_FIX_HOPS, x_proto=1, x_host=1)
 
 _CONFIG_DIR      = os.path.dirname(os.environ.get('SETTINGS_PATH', '/app/config/manager.yml'))
@@ -1240,6 +1246,7 @@ logger.info(f"Settings Path:  {SETTINGS_PATH}")
 logger.info(f"Backup Dir:     {BACKUP_DIR}")
 logger.info(f"Traefik API:    {_s['traefik_api_url']}")
 logger.info(f"Restart Method: {_restart_meth}")
+logger.info(f"Trusted Hops:   {PROXY_FIX_HOPS}")
 logger.info(f"Static Config:  {_static_path if _static_path else 'not configured'}")
 logger.info(f"Domains:        {_s['domains']}")
 logger.info(f"Cert Resolver:  {_s['cert_resolver'] or 'not set'}")

--- a/docs/env-vars.md
+++ b/docs/env-vars.md
@@ -80,6 +80,7 @@ Variables marked ✅ **override** the corresponding `manager.yml` field on every
 |---|---|---|---|
 | `SECRET_KEY` | _(auto-generated)_ | - | Flask session signing key |
 | `OTP_ENCRYPTION_KEY` | _(auto-generated)_ | - | Fernet key for encrypting TOTP secrets |
+| `PROXY_FIX_HOPS` | `1` | - | Number of trusted proxy hops in front of Traefik Manager for `X-Forwarded-For` |
 
 ---
 
@@ -693,4 +694,30 @@ python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().
 
 ::: warning
 If you lose this key, existing TOTP secrets become unreadable and 2FA must be re-enrolled. Back up `.otp_key` alongside your config volume.
+:::
+
+---
+
+### `PROXY_FIX_HOPS`
+
+**Default:** `1`
+
+How many trusted reverse-proxy hops sit in front of Traefik Manager. The app runs behind `ProxyFix`, which reads the client IP from the right of `X-Forwarded-For`; this value is how many positions it trusts. With a single proxy in front (Traefik → app) the default of `1` is correct. With two hops (e.g. Cloudflare → Traefik → app) the app's own login and audit logs would otherwise record the intermediate proxy's IP - set it to `2`.
+
+The active value is shown in the startup log as `Trusted Hops` and in the Client IP Diagnostic.
+
+:::tabs
+== Docker / Podman
+```yaml
+environment:
+  - PROXY_FIX_HOPS=2
+```
+== Linux (systemd)
+```ini
+Environment=PROXY_FIX_HOPS=2
+```
+:::
+
+::: warning
+Only count hops you actually control. Each trusted hop is one more `X-Forwarded-For` entry a client could forge, so setting this higher than your real proxy chain lets callers spoof their source IP past the login rate-limiter and audit log. Set it to `0` to ignore `X-Forwarded-For` entirely and use the direct connection IP.
 :::


### PR DESCRIPTION
The small standalone from #112 — making the trusted-hop count configurable, per the note there about two-hop setups (Cloudflare → Traefik → app) recording the wrong IP in the app's own login/audit logs.

> ⚠️ **Stacked on #113** — this branches off the diagnostic PR because it extends the same `PROXY_FIX_HOPS` line that #113 introduces. Until #113 merges, the diff below also shows that commit; it'll reduce to just this change once #113 lands. Happy to rebase onto `dev` the moment it does.

## What's in it

- New `PROXY_FIX_HOPS` env var (**default `1`, so no behaviour change**) sets `ProxyFix(x_for=…)`.
- Clamped to `>= 0` (`0` ignores `X-Forwarded-For` and uses the direct connection IP; invalid values fall back to `1`).
- Logged at startup as `Trusted Hops` and surfaced by the Client IP Diagnostic (#113).
- Docs: `env-vars.md` entry with an explicit spoofing warning (don't trust more hops than you control).

## Your call, as flagged in the thread
You wanted to settle the **default and the guidance** together — so treating this PR as the concrete proposal:
- **Default `1`** (matches today's hardcoded value; zero migration).
- **Guidance**: env-var only, no Settings-UI toggle — it's read once at startup like `COOKIE_SECURE`/`RESTART_METHOD`, and a runtime toggle would mean re-wrapping the WSGI app. The doc warns that each extra trusted hop is one more forgeable `X-Forwarded-For` entry.

Happy to adjust the default, the wording, or add a Settings surface if you'd rather.

## Verification
`ProxyFix(x_for=2)` with `X-Forwarded-For: <client>, <proxy>` resolves the client (2nd from right); default `1` unchanged; clamp/fallback covered.