### PR TITLE
feat: guided route-dialog presets — security headers + streaming

### DIFF
--- a/app.py
+++ b/app.py
@@ -644,6 +644,7 @@ def load_settings() -> dict:
         'otp_secret':           '',
         'otp_enabled':          False,
         'disabled_routes':      {},
+        'managed_middlewares':  {},
         'api_keys':             [],
         'api_key_enabled':      False,
         'self_route':           {'domain': '', 'service_url': ''},
@@ -734,6 +735,8 @@ def load_settings() -> dict:
                 merged['setup_complete'] = True
         if 'disabled_routes' in data and isinstance(data['disabled_routes'], dict):
             merged['disabled_routes'] = dict(data['disabled_routes'])
+        if 'managed_middlewares' in data and isinstance(data['managed_middlewares'], dict):
+            merged['managed_middlewares'] = dict(data['managed_middlewares'])
         if 'api_keys' in data and isinstance(data['api_keys'], list):
             keys = []
             for k in data['api_keys']:
@@ -849,6 +852,7 @@ def save_settings(domains, cert_resolver, traefik_api_url,
                   otp_secret=None, otp_enabled=None,
                   api_keys=None,
                   disabled_routes=None,
+                  managed_middlewares=None,
                   self_route=None,
                   acme_json_path=None,
                   access_log_path=None,
@@ -886,6 +890,8 @@ def save_settings(domains, cert_resolver, traefik_api_url,
         self_route = _cur.get('self_route', {'domain': '', 'service_url': ''})
     if disabled_routes is None:
         disabled_routes = _cur.get('disabled_routes', {})
+    if managed_middlewares is None:
+        managed_middlewares = _cur.get('managed_middlewares', {})
     if acme_json_path is None:
         acme_json_path = _cur.get('acme_json_path', '')
     if default_theme is None:
@@ -979,6 +985,7 @@ def save_settings(domains, cert_resolver, traefik_api_url,
         'otp_secret':           otp_secret,
         'otp_enabled':          otp_enabled,
         'disabled_routes':      disabled_routes,
+        'managed_middlewares':  managed_middlewares,
         'api_keys':             api_keys,
         'api_key_enabled':      len(list(api_keys)) > 0,
         'self_route':           self_route,
@@ -4272,6 +4279,134 @@ def _merge_service(section: dict, name: str, new_lb: dict, server_key: str, tran
         del existing_lb['serversTransport']
 
 
+def _json_plain(value: object) -> object:
+    import json as _json
+    try:
+        return _json.loads(_json.dumps(value, default=str))
+    except (TypeError, ValueError):
+        return value
+
+
+HEADERS_PRESET_FEATURES = (
+    'geolocation', 'camera', 'microphone', 'fullscreen', 'autoplay',
+    'payment', 'usb', 'display-capture', 'accelerometer', 'gyroscope', 'magnetometer',
+)
+HEADERS_PRESET_SELF_DEFAULT = ('geolocation', 'camera', 'microphone', 'fullscreen', 'autoplay')
+HEADERS_PRESET_HSTS_SECONDS = 31536000
+HEADERS_PRESET_REFERRER_DEFAULT = 'strict-origin-when-cross-origin'
+HEADERS_PRESET_REFERRER_VALUES = {
+    'no-referrer', 'strict-origin-when-cross-origin', 'same-origin',
+    'strict-origin', 'origin-when-cross-origin',
+}
+_PERM_VALUE_TO_TOKEN = {'self': '(self)', 'all': '*', 'block': '()'}
+_PERM_TOKEN_TO_VALUE = {'(self)': 'self', '*': 'all', '()': 'block'}
+_HEADERS_PRESET_KEYS = {
+    'customResponseHeaders', 'stsSeconds', 'stsIncludeSubdomains',
+    'contentTypeNosniff', 'frameDeny', 'referrerPolicy',
+}
+
+
+def _headers_preset_defaults() -> dict:
+    return {
+        'perms': {f: ('self' if f in HEADERS_PRESET_SELF_DEFAULT else 'block') for f in HEADERS_PRESET_FEATURES},
+        'hsts': True,
+        'nosniff': True,
+        'frameDeny': True,
+        'referrer': HEADERS_PRESET_REFERRER_DEFAULT,
+    }
+
+
+def _build_permissions_policy(perms: dict) -> str:
+    parts = []
+    for feat in HEADERS_PRESET_FEATURES:
+        token = _PERM_VALUE_TO_TOKEN.get(perms.get(feat, 'block'), '()')
+        parts.append(f"{feat}={token}")
+    return ', '.join(parts)
+
+
+def _build_headers_middleware(toggles: dict) -> dict:
+    headers = {}
+    pp = _build_permissions_policy(toggles.get('perms') or {})
+    if pp:
+        headers['customResponseHeaders'] = {'Permissions-Policy': pp}
+    if toggles.get('hsts'):
+        headers['stsSeconds'] = HEADERS_PRESET_HSTS_SECONDS
+        headers['stsIncludeSubdomains'] = True
+    if toggles.get('nosniff'):
+        headers['contentTypeNosniff'] = True
+    if toggles.get('frameDeny'):
+        headers['frameDeny'] = True
+    ref = (toggles.get('referrer') or '').strip()
+    if ref:
+        headers['referrerPolicy'] = ref
+    return {'headers': headers}
+
+
+def _parse_permissions_policy(value) -> dict | None:
+    if not isinstance(value, str):
+        return None
+    perms = {f: 'block' for f in HEADERS_PRESET_FEATURES}
+    for token in value.split(','):
+        token = token.strip()
+        if not token or '=' not in token:
+            return None
+        feat, _, raw = token.partition('=')
+        feat = feat.strip()
+        val = _PERM_TOKEN_TO_VALUE.get(raw.strip())
+        if feat not in HEADERS_PRESET_FEATURES or val is None:
+            return None
+        perms[feat] = val
+    return perms
+
+
+def _headers_toggles_from_form(form) -> dict:
+    perms = {}
+    for feat in HEADERS_PRESET_FEATURES:
+        val = form.get(f'hp_perm_{feat}', '')
+        perms[feat] = val if val in ('self', 'all', 'block') else 'block'
+    return {
+        'perms': perms,
+        'hsts': form.get('hp_hsts') == 'true',
+        'nosniff': form.get('hp_nosniff') == 'true',
+        'frameDeny': form.get('hp_frameDeny') == 'true',
+        'referrer': (form.get('hp_referrer') or '').strip(),
+    }
+
+
+def _decode_headers_middleware(body) -> dict | None:
+    plain = _json_plain(body)
+    if not isinstance(plain, dict) or set(plain.keys()) != {'headers'}:
+        return None
+    h = plain.get('headers')
+    if not isinstance(h, dict) or not set(h.keys()).issubset(_HEADERS_PRESET_KEYS):
+        return None
+    toggles = {
+        'perms': {f: 'block' for f in HEADERS_PRESET_FEATURES},
+        'hsts': False, 'nosniff': False, 'frameDeny': False, 'referrer': '',
+    }
+    crh = h.get('customResponseHeaders')
+    if crh is not None:
+        if not isinstance(crh, dict) or set(crh.keys()) - {'Permissions-Policy'}:
+            return None
+        parsed = _parse_permissions_policy(crh.get('Permissions-Policy'))
+        if parsed is None:
+            return None
+        toggles['perms'] = parsed
+    if 'stsSeconds' in h:
+        toggles['hsts'] = True
+    if 'contentTypeNosniff' in h:
+        toggles['nosniff'] = True
+    if 'frameDeny' in h:
+        toggles['frameDeny'] = True
+    if 'referrerPolicy' in h:
+        if h.get('referrerPolicy') not in HEADERS_PRESET_REFERRER_VALUES:
+            return None
+        toggles['referrer'] = h['referrerPolicy']
+    if _build_headers_middleware(toggles) != plain:
+        return None
+    return toggles
+
+
 def save_config(data, path=None):
     if path is None:
         path = CONFIG_PATH
@@ -4540,6 +4675,27 @@ def _build_all_apps(include_external=True, include_internal=False):
                     ep_mws.append(mw)
         app['entrypointMiddlewares'] = ep_mws
     settings = load_settings()
+    _mm_ledger = settings.get('managed_middlewares', {})
+    _http_mw_by_file = {cf: ((cfg.get('http') or {}).get('middlewares') or {}) for cf, cfg in loaded}
+    for app in all_apps:
+        if app.get('protocol') != 'http' or app.get('provider') != 'file':
+            continue
+        hdr_mw_name = f"{app.get('name')}-headers"
+        hdr_body    = _http_mw_by_file.get(app.get('configFile', ''), {}).get(hdr_mw_name)
+        owned       = hdr_mw_name in _mm_ledger
+        decoded     = _decode_headers_middleware(hdr_body) if (owned and hdr_body is not None) else None
+        if not owned or hdr_body is None:
+            hdr_state = 'off'
+        elif decoded is not None:
+            hdr_state = 'toggles'
+        else:
+            hdr_state = 'custom'
+        app['headersPreset'] = {
+            'owned':   owned,
+            'exists':  hdr_body is not None,
+            'state':   hdr_state,
+            'toggles': decoded if decoded is not None else _headers_preset_defaults(),
+        }
     for route_id, rdata in settings.get('disabled_routes', {}).items():
         if route_id.startswith('agent_'):
             continue  # agent disabled routes belong to that agent, not the host
@@ -5092,6 +5248,24 @@ def save_entry():
         plain_original_id = orig_parts[1] if len(orig_parts) > 1 else original_id
         orig_cfg_file = orig_parts[0] if len(orig_parts) > 1 else cfg_filename
 
+        _ledger            = settings.get('managed_middlewares', {})
+        _ledger_changed    = False
+        hdr_name           = f"{router_name}-headers"
+        hdr_ledger_key     = f"agent_{agent_id}::{hdr_name}" if agent else hdr_name
+        hdr_preset_present = protocol == 'http' and request.form.get('headersPresetPresent') == 'true'
+        hdr_preset_on      = hdr_preset_present and request.form.get('headersPresetEnabled') == 'true'
+        hdr_preset_custom  = request.form.get('headersPresetCustom') == 'true'
+        if hdr_preset_on:
+            _existing_hdr = config.get('http', {}).get('middlewares', {}).get(hdr_name)
+            _hdr_foreign  = _existing_hdr is not None and (
+                hdr_ledger_key not in _ledger or (is_edit and orig_cfg_file != cfg_filename))
+            if _hdr_foreign:
+                _msg = f"A middleware named '{hdr_name}' already exists and wasn't created by the route presets. Rename or remove it first, then re-save."
+                if fetch:
+                    return jsonify({'ok': False, 'message': _msg}), 409
+                flash(_msg, "error")
+                return redirect(url_for('index'))
+
         _prev_tcp_mws = None
         if is_edit and plain_original_id:
             _prev_src = config
@@ -5133,6 +5307,15 @@ def save_entry():
                 del old_transports[old_transport_name]
                 if not old_transports:
                     del http_sec['serversTransports']
+            old_hdr_name = f"{plain_original_id}-headers"
+            old_hdr_key  = f"agent_{agent_id}::{old_hdr_name}" if agent else old_hdr_name
+            if hdr_preset_present and old_hdr_key in _ledger:
+                old_hdr_mws = http_sec.get('middlewares', {})
+                old_hdr_mws.pop(old_hdr_name, None)
+                if not old_hdr_mws and 'middlewares' in http_sec:
+                    del http_sec['middlewares']
+                del _ledger[old_hdr_key]
+                _ledger_changed = True
             if agent:
                 _agent_write_config(agent, orig_cfg_file, old_config)
             elif orig_target_path:
@@ -5147,6 +5330,16 @@ def save_entry():
                     del old_routers[plain_original_id]
                 if old_svc and old_svc != service_name and 'services' in s and old_svc in s['services']:
                     del s['services'][old_svc]
+            if hdr_preset_present and plain_original_id != router_name:
+                rn_hdr_name = f"{plain_original_id}-headers"
+                rn_hdr_key  = f"agent_{agent_id}::{rn_hdr_name}" if agent else rn_hdr_name
+                if rn_hdr_key in _ledger:
+                    rn_hdr_mws = config.get('http', {}).get('middlewares', {})
+                    rn_hdr_mws.pop(rn_hdr_name, None)
+                    if not rn_hdr_mws and 'http' in config and 'middlewares' in config['http']:
+                        del config['http']['middlewares']
+                    del _ledger[rn_hdr_key]
+                    _ledger_changed = True
 
         if protocol == 'http':
             if http_rule:
@@ -5169,6 +5362,24 @@ def save_entry():
             insecure   = request.form.get('insecureSkipVerify') == 'true'
             config.setdefault('http', {}).setdefault('routers', {})
             config['http'].setdefault('services', {})
+            if hdr_preset_present:
+                if hdr_preset_on or hdr_ledger_key in _ledger:
+                    mws = [m for m in mws if m != hdr_name]
+                if hdr_preset_on and not hdr_preset_custom:
+                    config['http'].setdefault('middlewares', {})[hdr_name] = _build_headers_middleware(_headers_toggles_from_form(request.form))
+                _hdr_present_now = config.get('http', {}).get('middlewares', {}).get(hdr_name) is not None
+                if hdr_preset_on and _hdr_present_now:
+                    mws.append(hdr_name)
+                    if hdr_ledger_key not in _ledger:
+                        _ledger[hdr_ledger_key] = {'kind': 'route-headers', 'route': router_name}
+                        _ledger_changed = True
+                elif hdr_ledger_key in _ledger:
+                    _hdr_sec = config.get('http', {}).get('middlewares', {})
+                    _hdr_sec.pop(hdr_name, None)
+                    if not _hdr_sec and 'middlewares' in config['http']:
+                        del config['http']['middlewares']
+                    _ledger.pop(hdr_ledger_key, None)
+                    _ledger_changed = True
             r = {'rule': rule, 'entryPoints': http_eps, 'service': service_name}
             if mws:
                 r['middlewares'] = mws
@@ -5234,6 +5445,16 @@ def save_entry():
             _merge_service(config['udp']['services'], service_name,
                            {'servers': [{'address': f"{target_ip}:{target_port}"}]}, 'address', '')
 
+        if _ledger_changed:
+            save_settings(
+                domains=settings['domains'],
+                cert_resolver=settings['cert_resolver'],
+                traefik_api_url=settings['traefik_api_url'],
+                auth_enabled=settings['auth_enabled'],
+                password_hash=settings['password_hash'],
+                visible_tabs=settings['visible_tabs'],
+                managed_middlewares=_ledger,
+            )
         if agent:
             _agent_write_config(agent, cfg_filename, config)
             threading.Thread(target=lambda: _git_push_agent_if_enabled(agent, 'route save'), daemon=True).start()

--- a/app.py
+++ b/app.py
@@ -4279,6 +4279,10 @@ def _merge_service(section: dict, name: str, new_lb: dict, server_key: str, tran
         del existing_lb['serversTransport']
 
 
+def _streaming_forwarding_timeouts() -> dict:
+    return {'dialTimeout': '30s', 'responseHeaderTimeout': '0s', 'idleConnTimeout': '90s'}
+
+
 def _json_plain(value: object) -> object:
     import json as _json
     try:
@@ -4483,7 +4487,9 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
         tls_http = rdata.get('tls', {})
         transport_name = lb.get('serversTransport', '')
         transports_cfg = http_config.get('serversTransports') or {}
-        insecure = bool(_as_dict(transports_cfg.get(transport_name)).get('insecureSkipVerify', False)) if transport_name else False
+        transport_cfg  = _as_dict(transports_cfg.get(transport_name)) if transport_name else {}
+        insecure  = bool(transport_cfg.get('insecureSkipVerify', False))
+        streaming = 'forwardingTimeouts' in transport_cfg
         apps.append({'id': app_id, 'name': rname, 'rule': rdata.get('rule', ''),
                      'service_name': svc_name, 'target': target_url,
                      'middlewares': _to_list(rdata.get('middlewares')),
@@ -4494,6 +4500,7 @@ def _build_apps(config, config_file='', extra_http_svcs=None, extra_tcp_svcs=Non
                      'tlsDomains': tls_http.get('domains', []) if isinstance(tls_http, dict) else [],
                      'tlsOptionsProfile': tls_http.get('options', '') if isinstance(tls_http, dict) else '',
                      'insecureSkipVerify': insecure,
+                     'streaming': streaming,
                      'serviceType': _service_type(http_svcs.get(svc_key)),
                      'configFile': config_file, 'provider': 'file'})
     tcp_config = config.get('tcp') or {}
@@ -5255,6 +5262,8 @@ def save_entry():
         hdr_preset_present = protocol == 'http' and request.form.get('headersPresetPresent') == 'true'
         hdr_preset_on      = hdr_preset_present and request.form.get('headersPresetEnabled') == 'true'
         hdr_preset_custom  = request.form.get('headersPresetCustom') == 'true'
+        stream_preset_present = protocol == 'http' and request.form.get('streamingPresetPresent') == 'true'
+        stream_preset_on      = stream_preset_present and request.form.get('streamingPresetEnabled') == 'true'
         if hdr_preset_on:
             _existing_hdr = config.get('http', {}).get('middlewares', {}).get(hdr_name)
             _hdr_foreign  = _existing_hdr is not None and (
@@ -5397,18 +5406,28 @@ def save_entry():
                     tls_entry['options'] = tls_opts_profile
                 r['tls'] = tls_entry
             lb = {'servers': [{'url': target_url}]}
-            if not pass_host:
+            if not pass_host and not stream_preset_on:
                 lb['passHostHeader'] = False
             transport_name = f"{svc_name}-transport"
+            existing_transports = config.get('http', {}).get('serversTransports', {})
+            tp = existing_transports.get(transport_name)
+            tp = tp if isinstance(tp, dict) else {}
             if insecure:
+                tp['insecureSkipVerify'] = True
+            else:
+                tp.pop('insecureSkipVerify', None)
+            if stream_preset_present:
+                if stream_preset_on:
+                    tp['forwardingTimeouts'] = _streaming_forwarding_timeouts()
+                else:
+                    tp.pop('forwardingTimeouts', None)
+            if tp:
+                config['http'].setdefault('serversTransports', {})[transport_name] = tp
                 lb['serversTransport'] = transport_name
-                config['http'].setdefault('serversTransports', {})[transport_name] = {'insecureSkipVerify': True}
-            elif not insecure:
-                existing_transports = config.get('http', {}).get('serversTransports', {})
-                if transport_name in existing_transports:
-                    del existing_transports[transport_name]
-                    if not existing_transports:
-                        del config['http']['serversTransports']
+            elif transport_name in existing_transports:
+                del existing_transports[transport_name]
+                if not existing_transports and 'serversTransports' in config['http']:
+                    del config['http']['serversTransports']
             _merge_router(config['http']['routers'], router_name, r,
                           ('rule', 'entryPoints', 'service', 'middlewares', 'tls'))
             _merge_service(config['http']['services'], service_name, lb, 'url', transport_name)

--- a/docs/manager-yml.md
+++ b/docs/manager-yml.md
@@ -75,6 +75,7 @@ visible_tabs:
   plugins: false
   logs: true
 disabled_routes: {}
+managed_middlewares: {}
 self_route:
   domain: ""
   service_url: ""
@@ -426,6 +427,21 @@ Controls which optional tabs are shown. Managed via the setup wizard or **Settin
 **Type:** map - **Default:** `{}`
 
 Stores the full config of disabled routes so they can be re-enabled without data loss. Managed automatically by the enable/disable toggle. Do not edit by hand.
+
+---
+
+### `managed_middlewares`
+
+**Type:** map - **Default:** `{}`
+
+Ownership ledger for middlewares that traefik-manager generated on your behalf - currently the `<route>-headers` middleware created by the [Security headers preset](./tab-routes#security-headers-preset). Each entry records that the tool created that middleware, so it will only ever update or remove middlewares it owns, and refuses to overwrite a same-named middleware you wrote by hand. Managed automatically; do not edit by hand.
+
+```yaml
+managed_middlewares:
+  jellyfin-headers:
+    kind: route-headers
+    route: jellyfin
+```
 
 ---
 

--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -54,6 +54,7 @@ Click **Add Route** in the top bar. Fill in:
 | TLS Options Profile | Appears when a cert resolver is selected. Select a named `tls.options` profile from the TLS Options tab to assign it to this router (e.g. `modern`, `strict`). Leave blank to use Traefik's default TLS settings. |
 | Skip TLS Verification | Adds `insecureSkipVerify: true` via a named `serversTransport` entry. Use for backends with self-signed certificates (e.g. Proxmox, Kasm). A yellow **TLS skip** badge appears on the route card. |
 | Security headers preset | *(HTTP only)* Generates a tool-managed `<route>-headers` middleware with a `Permissions-Policy` and common security headers, and attaches it to the router. See [Security headers preset](#security-headers-preset) below. |
+| Optimize for streaming | *(HTTP only)* Sets long `forwardingTimeouts` on the service's `serversTransport` and forces `passHostHeader`, for media servers (Jellyfin/Emby/Plex). See [Streaming preset](#streaming-preset) below. |
 | Config File | Shown when multiple config files are mounted (`CONFIG_DIR` / `CONFIG_PATHS`). Select an existing file or choose **+ New file...** to type a filename - the file is created automatically in `CONFIG_DIR`. The `.yml` extension is added automatically if omitted. |
 
 For TCP routes, enter a raw SNI rule (`HostSNI(\`*\`)` for passthrough). UDP routes route by entry point only - no rule needed.
@@ -91,6 +92,28 @@ The generated middleware is a **normal, visible, editable file middleware** - it
 - Renaming a route moves its `<route>-headers` middleware to match the new name.
 
 The preset is available for local (file-provider) HTTP routes; routes on a remote agent are unaffected.
+
+## Streaming preset
+
+The **Optimize for streaming** toggle tunes an HTTP route for media servers (Jellyfin, Emby, Plex), where long transcodes otherwise time out and seeking breaks. On save it:
+
+- sets `forwardingTimeouts` on the service's `<service>-transport` serversTransport (`responseHeaderTimeout: 0s` - unlimited, so long transcodes aren't cut off - plus a `dialTimeout` and `idleConnTimeout`), and
+- forces `passHostHeader` on.
+
+```yaml
+serversTransports:
+  jellyfin-transport:
+    forwardingTimeouts:
+      dialTimeout: "30s"
+      responseHeaderTimeout: "0s"
+      idleConnTimeout: "90s"
+```
+
+It shares the same `<service>-transport` as [Skip TLS Verification](#creating-a-route), so the two compose: turning one off leaves the other's key in place, and the transport is removed only when both are off. Turning streaming off removes just the `forwardingTimeouts` key.
+
+Streaming works best **without response buffering** - if a `buffering` or `compress` middleware is attached to the route, the form warns you to remove it. Entry-point `respondingTimeouts` are global and static, so they are not changed here; adjust them in the [Static Config editor](./static) if long transcodes still cut off.
+
+Like the headers preset, streaming is managed only through the route modal for local HTTP routes; API, agent and other saves leave the transport untouched.
 
 ## Deleting a route
 

--- a/docs/tab-routes.md
+++ b/docs/tab-routes.md
@@ -53,6 +53,7 @@ Click **Add Route** in the top bar. Fill in:
 | Request wildcard certificate | Appears when a cert resolver is selected. Check this to add a `tls.domains` block with `main: yourdomain.com` and `sans: *.yourdomain.com` auto-filled from the selected domain. Use with DNS challenge resolvers (Cloudflare, Route 53, etc.) to request a wildcard certificate that covers all subdomains. |
 | TLS Options Profile | Appears when a cert resolver is selected. Select a named `tls.options` profile from the TLS Options tab to assign it to this router (e.g. `modern`, `strict`). Leave blank to use Traefik's default TLS settings. |
 | Skip TLS Verification | Adds `insecureSkipVerify: true` via a named `serversTransport` entry. Use for backends with self-signed certificates (e.g. Proxmox, Kasm). A yellow **TLS skip** badge appears on the route card. |
+| Security headers preset | *(HTTP only)* Generates a tool-managed `<route>-headers` middleware with a `Permissions-Policy` and common security headers, and attaches it to the router. See [Security headers preset](#security-headers-preset) below. |
 | Config File | Shown when multiple config files are mounted (`CONFIG_DIR` / `CONFIG_PATHS`). Select an existing file or choose **+ New file...** to type a filename - the file is created automatically in `CONFIG_DIR`. The `.yml` extension is added automatically if omitted. |
 
 For TCP routes, enter a raw SNI rule (`HostSNI(\`*\`)` for passthrough). UDP routes route by entry point only - no rule needed.
@@ -66,6 +67,30 @@ Saving only rewrites the parts of the route the form owns: the rule, entry point
 ::: warning Advanced service types
 If a router points at a `weighted`, `mirroring` or `failover` service instead of a `loadBalancer`, that service is left untouched, so editing the target field in the modal has no effect on it. Edit those services directly in the config file.
 :::
+
+## Security headers preset
+
+The **Security headers preset** toggle in the HTTP route form generates a middleware that sets a `Permissions-Policy` and the common security headers, so you don't have to hand-write one. When enabled on save it:
+
+- creates a middleware named `<route>-headers` under `http.middlewares` and attaches it to the router, and
+- records ownership in `manager.yml` under [`managed_middlewares`](./manager-yml#managed-middlewares) so the tool knows it created it.
+
+The generated middleware is a **normal, visible, editable file middleware** - it appears in the [Middlewares tab](./tab-middlewares) like any other and you can hand-tune it there.
+
+**Toggles:**
+
+- **Permissions-Policy** - each browser feature (`geolocation`, `camera`, `microphone`, `fullscreen`, `autoplay`, `payment`, `usb`, `display-capture`, `accelerometer`, `gyroscope`, `magnetometer`) can be set to **self** (only your site), **all** (any site), or **block**. The default allows `self` for the first five and blocks the rest, written via `customResponseHeaders` so it stays version-independent.
+- **HSTS** - `stsSeconds: 31536000` + `stsIncludeSubdomains` (force HTTPS for a year).
+- **Content-Type nosniff**, **Frame deny** (anti-clickjacking), and a **Referrer-Policy** selector.
+
+**Round-trip and safety:**
+
+- Re-opening the route reads the middleware back into the toggles. If you have hand-edited `<route>-headers` beyond what the toggles can represent, the form shows it as **custom** and leaves your content untouched - change any toggle to regenerate it, or turn the preset off to remove it.
+- Turning the preset off removes the `<route>-headers` middleware, detaches it from the router, and clears the ledger entry - but only if the tool created it.
+- If a middleware named `<route>-headers` already exists and was **not** created by the preset, the save is refused with a clear message so a hand-authored middleware is never overwritten. Rename or remove it first.
+- Renaming a route moves its `<route>-headers` middleware to match the new name.
+
+The preset is available for local (file-provider) HTTP routes; routes on a remote agent are unaffected.
 
 ## Deleting a route
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -136,6 +136,8 @@ main { overflow-x: hidden; }
 }
 .input-field:focus { border-color: var(--blue); box-shadow: 0 0 0 3px rgba(36,161,222,0.1); }
 .input-field::placeholder { color: var(--muted); }
+input[type="search"].input-field::-webkit-search-cancel-button,
+input[type="search"].input-field::-webkit-search-decoration { -webkit-appearance: none; appearance: none; }
 select.input-field {
     appearance: none;
     -webkit-appearance: none;

--- a/templates/index.html
+++ b/templates/index.html
@@ -932,6 +932,100 @@ function _applyServiceTypeNotice(svcType) {
     });
 }
 
+const HP_FEATURES = ['geolocation','camera','microphone','fullscreen','autoplay','payment','usb','display-capture','accelerometer','gyroscope','magnetometer'];
+const HP_SELF_DEFAULT = ['geolocation','camera','microphone','fullscreen','autoplay'];
+
+function _hpDefaults() {
+    const perms = {};
+    HP_FEATURES.forEach(f => perms[f] = HP_SELF_DEFAULT.includes(f) ? 'self' : 'block');
+    return { perms, hsts: true, nosniff: true, frameDeny: true, referrer: 'strict-origin-when-cross-origin' };
+}
+
+function _buildHeadersPresetPerms() {
+    const host = document.getElementById('hpPerms');
+    if (!host || host.dataset.built) return;
+    host.dataset.built = '1';
+    HP_FEATURES.forEach(f => {
+        const wrap = document.createElement('div');
+        wrap.className = 'flex items-center justify-between gap-2';
+        wrap.innerHTML = `<span class="text-sm" style="color:var(--text)">${f}</span>`
+            + `<select id="hp_perm_${f}" name="hp_perm_${f}" onchange="_hpUserEdited()" class="input-field" style="max-width:9rem">`
+            + `<option value="self">self</option><option value="all">all</option><option value="block">block</option></select>`;
+        host.appendChild(wrap);
+    });
+}
+
+function _applyHeadersPresetToggles(t) {
+    HP_FEATURES.forEach(f => {
+        const sel = document.getElementById('hp_perm_' + f);
+        if (sel) sel.value = (t.perms && t.perms[f]) || 'block';
+    });
+    document.getElementById('hp_hsts').checked = !!t.hsts;
+    document.getElementById('hp_nosniff').checked = !!t.nosniff;
+    document.getElementById('hp_frameDeny').checked = !!t.frameDeny;
+    document.getElementById('hp_referrer').value = t.referrer || '';
+}
+
+function _renderHeadersPresetState(on, custom) {
+    document.getElementById('hpBody').style.display = (on && !custom) ? '' : 'none';
+    const notice = document.getElementById('hpCustomNotice');
+    notice.style.display = (on && custom) ? '' : 'none';
+    if (on && custom) {
+        const el = document.getElementById('hpCustomName');
+        if (el) el.textContent = document.getElementById('serviceName').value + '-headers';
+    }
+}
+
+function _hpUserEdited() {
+    document.getElementById('headersPresetCustom').value = 'false';
+    _renderHeadersPresetState(document.getElementById('hpEnabled').checked, false);
+}
+
+function _onHeadersPresetToggle(on) {
+    document.getElementById('headersPresetEnabled').value = on ? 'true' : 'false';
+    document.getElementById('headersPresetCustom').value = 'false';
+    _renderHeadersPresetState(on, false);
+}
+
+function _resetHeadersPreset() {
+    const section = document.getElementById('headersPresetSection');
+    if (!section) return;
+    _buildHeadersPresetPerms();
+    const host = !_activeAgent;
+    section.style.display = host ? '' : 'none';
+    document.getElementById('hpEnabled').checked = false;
+    _applyHeadersPresetToggles(_hpDefaults());
+    document.getElementById('headersPresetPresent').value = host ? 'true' : '';
+    document.getElementById('headersPresetEnabled').value = 'false';
+    document.getElementById('headersPresetCustom').value = 'false';
+    _renderHeadersPresetState(false, false);
+}
+
+function _applyHeadersPreset(hp) {
+    const section = document.getElementById('headersPresetSection');
+    if (!section) return;
+    _buildHeadersPresetPerms();
+    if (!hp || _activeAgent) {
+        section.style.display = 'none';
+        document.getElementById('hpEnabled').checked = false;
+        _applyHeadersPresetToggles(_hpDefaults());
+        document.getElementById('headersPresetPresent').value = '';
+        document.getElementById('headersPresetEnabled').value = 'false';
+        document.getElementById('headersPresetCustom').value = 'false';
+        _renderHeadersPresetState(false, false);
+        return;
+    }
+    section.style.display = '';
+    const on = hp.state === 'toggles' || hp.state === 'custom';
+    const custom = hp.state === 'custom';
+    document.getElementById('hpEnabled').checked = on;
+    _applyHeadersPresetToggles(hp.toggles || _hpDefaults());
+    document.getElementById('headersPresetPresent').value = 'true';
+    document.getElementById('headersPresetEnabled').value = on ? 'true' : 'false';
+    document.getElementById('headersPresetCustom').value = custom ? 'true' : 'false';
+    _renderHeadersPresetState(on, custom);
+}
+
 async function openModal() {
     document.getElementById('isEdit').value = 'false';
     document.getElementById('modalTitle').innerText = 'Add Route';
@@ -958,6 +1052,7 @@ async function openModal() {
     const mainEl = document.getElementById('tlsWildcardMain'); if (mainEl) mainEl.value = '';
     const sansEl = document.getElementById('tlsWildcardSans'); if (sansEl) sansEl.value = '';
     setProtocol('http');
+    _resetHeadersPreset();
     const tlsOptSel = document.getElementById('tlsOptionsProfileSelect');
     if (tlsOptSel) tlsOptSel.value = '';
     _populateTlsOptionsSelect();
@@ -2294,7 +2389,9 @@ async function cloneRoute(btn) {
         const parts = target.split(':');
         document.getElementById('targetIp').value = parts[0] || '';
         document.getElementById('targetPort').value = parts[1] || '80';
-        await _initMiddlewareChips(app.middlewares || []);
+        const _ownedHdr = (app.headersPreset && app.headersPreset.owned) ? app.name + '-headers' : null;
+        await _initMiddlewareChips((app.middlewares || []).filter(m => m !== _ownedHdr));
+        _applyHeadersPreset(app.headersPreset);
         await _initEntrypointChips('http', app.entryPoints || []);
         document.getElementById('scheme').value = targetScheme;
         document.getElementById('passHostHeader').checked = app.passHostHeader !== false;
@@ -2404,7 +2501,9 @@ async function handleEdit(btn) {
         const parts = target.split(':');
         document.getElementById('targetIp').value = parts[0];
         document.getElementById('targetPort').value = parts[1] || '80';
-        await _initMiddlewareChips(app.middlewares || []);
+        const _ownedHdr = (app.headersPreset && app.headersPreset.owned) ? app.name + '-headers' : null;
+        await _initMiddlewareChips((app.middlewares || []).filter(m => m !== _ownedHdr));
+        _applyHeadersPreset(app.headersPreset);
         await _initEntrypointChips('http', app.entryPoints || []);
         document.getElementById('scheme').value = targetScheme;
         document.getElementById('passHostHeader').checked = app.passHostHeader !== false;

--- a/templates/index.html
+++ b/templates/index.html
@@ -1016,14 +1016,87 @@ function _applyHeadersPreset(hp) {
         return;
     }
     section.style.display = '';
-    const on = hp.state === 'toggles' || hp.state === 'custom';
-    const custom = hp.state === 'custom';
+    let state = hp.state;
+    if (state === 'custom' && document.getElementById('isEdit').value === 'false') state = 'off';
+    const on = state === 'toggles' || state === 'custom';
+    const custom = state === 'custom';
     document.getElementById('hpEnabled').checked = on;
     _applyHeadersPresetToggles(hp.toggles || _hpDefaults());
     document.getElementById('headersPresetPresent').value = 'true';
     document.getElementById('headersPresetEnabled').value = on ? 'true' : 'false';
     document.getElementById('headersPresetCustom').value = custom ? 'true' : 'false';
     _renderHeadersPresetState(on, custom);
+}
+
+function _streamingBufWarn() {
+    const el = document.getElementById('streamingBufWarn');
+    if (!el) return;
+    const mws = (document.getElementById('middlewares').value || '').split(',').map(s => s.trim());
+    el.style.display = mws.some(m => /(?:^|[-_.])(?:buffering|compress)(?:[-_.]|$)/i.test(m)) ? '' : 'none';
+}
+
+function _clearStreamingForce() {
+    const ph = document.getElementById('passHostHeader');
+    if (ph) { ph.disabled = false; delete ph.dataset.streamPrev; }
+}
+
+function _renderStreamingState(on) {
+    document.getElementById('streamingNote').style.display = on ? '' : 'none';
+    const ph = document.getElementById('passHostHeader');
+    if (ph) {
+        if (on) {
+            if (ph.dataset.streamPrev === undefined) ph.dataset.streamPrev = ph.checked ? 'true' : 'false';
+            ph.checked = true;
+            ph.disabled = true;
+        } else {
+            ph.disabled = false;
+            if (ph.dataset.streamPrev !== undefined) {
+                ph.checked = ph.dataset.streamPrev === 'true';
+                delete ph.dataset.streamPrev;
+            }
+        }
+    }
+    if (on) {
+        const el = document.getElementById('streamingTpName');
+        if (el) el.textContent = document.getElementById('serviceName').value + '-transport';
+        _streamingBufWarn();
+    }
+}
+
+function _onStreamingToggle(on) {
+    document.getElementById('streamingPresetEnabled').value = on ? 'true' : 'false';
+    _renderStreamingState(on);
+}
+
+function _resetStreamingPreset() {
+    const section = document.getElementById('streamingPresetSection');
+    if (!section) return;
+    _clearStreamingForce();
+    const host = !_activeAgent;
+    section.style.display = host ? '' : 'none';
+    document.getElementById('streamingEnabled').checked = false;
+    document.getElementById('streamingPresetPresent').value = host ? 'true' : '';
+    document.getElementById('streamingPresetEnabled').value = 'false';
+    _renderStreamingState(false);
+}
+
+function _applyStreamingPreset(on) {
+    const section = document.getElementById('streamingPresetSection');
+    if (!section) return;
+    _clearStreamingForce();
+    if (on == null || _activeAgent) {
+        section.style.display = 'none';
+        document.getElementById('streamingEnabled').checked = false;
+        document.getElementById('streamingPresetPresent').value = '';
+        document.getElementById('streamingPresetEnabled').value = 'false';
+        _renderStreamingState(false);
+        return;
+    }
+    section.style.display = '';
+    document.getElementById('streamingEnabled').checked = !!on;
+    document.getElementById('streamingPresetPresent').value = 'true';
+    document.getElementById('streamingPresetEnabled').value = on ? 'true' : 'false';
+    _renderStreamingState(!!on);
 }
 
 async function openModal() {
@@ -1053,6 +1126,7 @@ async function openModal() {
     const sansEl = document.getElementById('tlsWildcardSans'); if (sansEl) sansEl.value = '';
     setProtocol('http');
     _resetHeadersPreset();
+    _resetStreamingPreset();
     const tlsOptSel = document.getElementById('tlsOptionsProfileSelect');
     if (tlsOptSel) tlsOptSel.value = '';
     _populateTlsOptionsSelect();
@@ -2278,6 +2352,7 @@ async function _initMiddlewareChips(selectedMiddlewares, proto) {
         container.innerHTML = sel.map((mw, i) => chip(mw, i, true)).join('')
             + divider
             + unsel.map(mw => chip(mw, 0, false)).join('');
+        if (proto !== 'tcp') _streamingBufWarn();
     }
     render();
     if (!window._mwChipState || typeof window._mwChipState.render === 'function') window._mwChipState = {};
@@ -2395,6 +2470,7 @@ async function cloneRoute(btn) {
         await _initEntrypointChips('http', app.entryPoints || []);
         document.getElementById('scheme').value = targetScheme;
         document.getElementById('passHostHeader').checked = app.passHostHeader !== false;
+        _applyStreamingPreset(app.streaming);
         const crHttp = document.getElementById('certResolver');
         if (crHttp) {
             if (!app.tls && app.tls !== false) crHttp.value = '__disabled__';
@@ -2507,6 +2583,7 @@ async function handleEdit(btn) {
         await _initEntrypointChips('http', app.entryPoints || []);
         document.getElementById('scheme').value = targetScheme;
         document.getElementById('passHostHeader').checked = app.passHostHeader !== false;
+        _applyStreamingPreset(app.streaming);
         const crHttp = document.getElementById('certResolver');
         if (crHttp) {
             if (!app.tls && app.tls !== false) crHttp.value = '__disabled__';

--- a/templates/modals/route_modal.html
+++ b/templates/modals/route_modal.html
@@ -161,6 +161,21 @@
                             </div>
                         </div>
                     </div>
+                    <div id="streamingPresetSection">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <input type="checkbox" id="streamingEnabled" onchange="_onStreamingToggle(this.checked)" class="rounded" style="accent-color:var(--blue)">
+                                <span class="text-sm" style="color:var(--text)">Optimize for streaming (Jellyfin / Emby / Plex)</span>
+                            </div>
+                            <span class="tm-info-btn" data-tip="Sets forwardingTimeouts on the service's serversTransport (unlimited response-header timeout for long transcodes) and forces passHostHeader. Composes with Skip TLS Verification on the same transport."><i class="ph-bold ph-info"></i></span>
+                        </div>
+                        <input type="hidden" name="streamingPresetPresent" id="streamingPresetPresent" value="">
+                        <input type="hidden" name="streamingPresetEnabled" id="streamingPresetEnabled" value="false">
+                        <div id="streamingNote" class="text-xs mt-2 p-2 rounded-lg" style="display:none;background:var(--input-bg);border:1px solid var(--border);color:var(--muted)">
+                            Forces <code>passHostHeader</code> and sets long <code>forwardingTimeouts</code> on <code><span id="streamingTpName"></span></code>. Entry-point <code>respondingTimeouts</code> are global and static — adjust them in the Static Config editor if long transcodes still cut off.
+                            <span id="streamingBufWarn" style="display:none;color:var(--yellow, #d4a017)"><br>⚠ A <code>buffering</code>/<code>compress</code> middleware is attached — remove it for smooth streaming and seeking.</span>
+                        </div>
+                    </div>
                     <div id="wildcardCheckboxRow" style="display:none" class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <input type="checkbox" id="wildcardCheckbox" onchange="_onWildcardToggle(this.checked)" class="rounded" style="accent-color:var(--blue)">

--- a/templates/modals/route_modal.html
+++ b/templates/modals/route_modal.html
@@ -126,6 +126,41 @@
                         </div>
                         <span class="tm-info-btn" data-tip="Disables certificate validation for the backend. Use for self-signed certs (e.g. Proxmox, Kasm). Adds insecureSkipVerify via a named serversTransport."><i class="ph-bold ph-info"></i></span>
                     </div>
+                    <div id="headersPresetSection">
+                        <div class="flex items-center justify-between">
+                            <div class="flex items-center gap-2">
+                                <input type="checkbox" id="hpEnabled" onchange="_onHeadersPresetToggle(this.checked)" class="rounded" style="accent-color:var(--blue)">
+                                <span class="text-sm" style="color:var(--text)">Security headers preset</span>
+                            </div>
+                            <span class="tm-info-btn" data-tip="Creates a tool-managed <route>-headers middleware: a Permissions-Policy plus common security headers (HSTS, nosniff, frame-deny, referrer). It stays a normal, editable file middleware in the Middlewares tab."><i class="ph-bold ph-info"></i></span>
+                        </div>
+                        <input type="hidden" name="headersPresetPresent" id="headersPresetPresent" value="">
+                        <input type="hidden" name="headersPresetEnabled" id="headersPresetEnabled" value="false">
+                        <input type="hidden" name="headersPresetCustom" id="headersPresetCustom" value="false">
+                        <div id="hpCustomNotice" class="text-xs mt-2 p-2 rounded-lg" style="display:none;background:rgba(240,180,0,0.1);border:1px solid rgba(240,180,0,0.3);color:var(--text)">
+                            The <code id="hpCustomName"></code> middleware has been hand-edited beyond what these toggles cover, so it's shown as custom and kept as-is. Edit it in the Middlewares tab, or turn the preset off and on again to replace it with the toggle defaults. Turn it off to remove it.
+                        </div>
+                        <div id="hpBody" class="mt-2 p-3 rounded-lg" style="display:none;background:var(--input-bg);border:1px solid var(--border)">
+                            <p class="text-xs mb-2" style="color:var(--muted)">Permissions-Policy — who may use each browser feature. <code>self</code> = only your own site · <code>all</code> = any site, including embedded iframes · <code>block</code> = no one.</p>
+                            <div id="hpPerms" class="grid grid-cols-2 gap-2"></div>
+                            <div class="grid grid-cols-2 gap-2 mt-3">
+                                <label class="flex items-center gap-2 text-sm" style="color:var(--text)"><input type="checkbox" name="hp_hsts" id="hp_hsts" value="true" onchange="_hpUserEdited()" class="rounded" style="accent-color:var(--blue)"> HSTS (force HTTPS)</label>
+                                <label class="flex items-center gap-2 text-sm" style="color:var(--text)"><input type="checkbox" name="hp_nosniff" id="hp_nosniff" value="true" onchange="_hpUserEdited()" class="rounded" style="accent-color:var(--blue)"> Content-Type nosniff</label>
+                                <label class="flex items-center gap-2 text-sm" style="color:var(--text)"><input type="checkbox" name="hp_frameDeny" id="hp_frameDeny" value="true" onchange="_hpUserEdited()" class="rounded" style="accent-color:var(--blue)"> Frame deny (anti-clickjacking)</label>
+                                <div>
+                                    <label class="text-sm" style="color:var(--text)">Referrer-Policy</label>
+                                    <select name="hp_referrer" id="hp_referrer" onchange="_hpUserEdited()" class="input-field">
+                                        <option value="">(none)</option>
+                                        <option value="no-referrer">no-referrer</option>
+                                        <option value="strict-origin-when-cross-origin">strict-origin-when-cross-origin</option>
+                                        <option value="same-origin">same-origin</option>
+                                        <option value="strict-origin">strict-origin</option>
+                                        <option value="origin-when-cross-origin">origin-when-cross-origin</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                     <div id="wildcardCheckboxRow" style="display:none" class="flex items-center justify-between">
                         <div class="flex items-center gap-2">
                             <input type="checkbox" id="wildcardCheckbox" onchange="_onWildcardToggle(this.checked)" class="rounded" style="accent-color:var(--blue)">

--- a/templates/tabs/tab_dashboard.html
+++ b/templates/tabs/tab_dashboard.html
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap gap-2 mb-4 items-center filter-bar">
         <div class="relative flex-1 min-w-48">
             <i class="ph-bold ph-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-sm" style="color:var(--muted)"></i>
-            <input type="text" id="dashSearch" oninput="dashApplyFilter()" placeholder="Search routes..." class="input-field pl-9">
+            <input type="search" id="dashSearch" oninput="dashApplyFilter()" placeholder="Search routes..." class="input-field pl-9" autocomplete="off" name="dash-search-nofill">
         </div>
         <div class="flex gap-1 p-1 rounded-lg" style="background:var(--input-bg); border:1px solid var(--border)">
             <button onclick="dashFilterProto('all')"  id="dashf-all"  class="proto-btn active-http text-xs px-3 py-1.5">All</button>

--- a/templates/tabs/tab_routemap.html
+++ b/templates/tabs/tab_routemap.html
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap gap-2 mb-4 items-center filter-bar">
         <div class="relative flex-1 min-w-48">
             <i class="ph-bold ph-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-sm" style="color:var(--muted)"></i>
-            <input type="text" id="rmSearch" oninput="rmApplyFilter()" placeholder="Search routes..." class="input-field pl-9">
+            <input type="search" id="rmSearch" oninput="rmApplyFilter()" placeholder="Search routes..." class="input-field pl-9" autocomplete="off" name="routemap-search-nofill">
         </div>
         <div class="flex gap-1 p-1 rounded-lg" style="background:var(--input-bg);border:1px solid var(--border)">
             <button onclick="rmFilterProto('all','All')"  id="rmf-all"  class="proto-btn active-http text-xs px-3 py-1.5">All</button>

--- a/templates/tabs/tab_services.html
+++ b/templates/tabs/tab_services.html
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap gap-2 mb-4 items-center filter-bar">
         <div class="relative flex-1 min-w-48">
             <i class="ph-bold ph-magnifying-glass absolute left-3 top-1/2 -translate-y-1/2 text-sm" style="color:var(--muted)"></i>
-            <input type="text" id="searchRoutes" oninput="filterRoutes()" placeholder="Search routes..." class="input-field pl-9">
+            <input type="search" id="searchRoutes" oninput="filterRoutes()" placeholder="Search routes..." class="input-field pl-9" autocomplete="off" name="route-search-nofill">
         </div>
         <div class="flex gap-1 p-1 rounded-lg fb-secondary" style="background:var(--input-bg); border:1px solid var(--border)">
             <div class="live-dd" id="dd-route-domain">


### PR DESCRIPTION
Piece 3 of #112 — the guided presets in the route dialog. Two focused, opt-in additions to the HTTP route form, each generating the right dynamic config underneath and reading back cleanly on edit. Built to the design we locked in the thread.

## 1. Security headers preset

Toggling it on generates a tool-managed `<route>-headers` middleware and attaches it to the router:

- **Permissions-Policy** per feature (`geolocation`, `camera`, `microphone`, `fullscreen`, `autoplay`, `payment`, `usb`, `display-capture`, `accelerometer`, `gyroscope`, `magnetometer`) as **self / all / block** — default allows `self` for the first five, blocks the rest — written via `customResponseHeaders` so it stays version-safe.
- **HSTS**, **Content-Type nosniff**, **Frame deny**, **Referrer-Policy**.

It stays a **normal, visible, editable file middleware** in the Middlewares tab.

**Ownership & safety** (the data-loss-sensitive part we agreed on):
- Ownership is tracked in a new `managed_middlewares` ledger in `manager.yml` (mirrors `disabled_routes`/`self_route`), so the tool only ever updates/removes middlewares **it** created.
- **Refuse-to-overwrite**: if `<route>-headers` already exists and isn't in the ledger, the save is rejected with a clear message **before touching anything** — a hand-authored middleware of the same name is never clobbered.
- Opening the route reads the middleware back into the toggles; if it's been **hand-edited beyond what the toggles represent** it's shown as **custom** and left as-is (never flattened).
- The middleware moves with the route on rename/file change; the whole lifecycle is gated behind the modal, so API/agent/other saves leave middlewares and the ledger untouched.

Default `1`-style behaviour: a route that never touches the preset is byte-identical to before.

## 2. Streaming preset ("Optimize for streaming")

For media servers (Jellyfin/Emby/Plex), where long transcodes time out and seeking breaks:

- Sets `forwardingTimeouts` on the service's `<service>-transport` (`responseHeaderTimeout: 0s`) and forces `passHostHeader`.
- The `<service>-transport` is now merged **non-destructively** rather than replaced, so it **composes with Skip TLS Verification** on the same transport and any hand-added keys survive; the transport is removed only when both features are off.
- Warns when a `buffering`/`compress` middleware is attached; notes that entrypoint `respondingTimeouts` are static (links to the Static Config editor) rather than changing them silently.

## Docs

`docs/tab-routes.md` (both presets) and `docs/manager-yml.md` (the `managed_middlewares` ledger).

## Also included (small, unrelated)

One extra commit fixes password-manager autofill covering the **route search fields** (Routes/Dashboard/Route Map): they were `type=text`; switched to `type=search` + `autocomplete=off`. Happy to split this into its own PR if you'd prefer to keep this one to the presets.

## Verification

No test suite in-repo, so verified manually against a stubbed Traefik via the real `/save` endpoint: create/readback/remove, refuse-to-overwrite (route left uncreated, hand-made middleware untouched), non-modal saves leave everything intact, custom-state preservation, rename moves the middleware, both presets + insecure composing on one transport, and a plain route staying byte-identical to `dev`. Backups are written on every config change and comment/formatting is preserved (ruamel round-trip).