### PR TITLE
feat: make modals horizontally resizable

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -261,6 +261,27 @@ select.input-field:disabled { opacity: 0.6; cursor: not-allowed; }
     overflow-y: auto;
     box-shadow: 0 24px 80px rgba(0,0,0,0.6);
 }
+.modal-box-route,
+.modal-box-tls,
+.modal-box-ipdiag,
+.modal-box-mw,
+.modal-box-trusted-ips,
+.modal-box-rm-groups,
+.modal-box-rm-edit,
+.modal-box-settings {
+    max-width: 95vw;
+    overflow-x: hidden;
+    resize: horizontal;
+    border-bottom-right-radius: 4px;
+}
+.modal-box-route      { width: 560px; min-width: 560px; }
+.modal-box-tls        { width: 560px; min-width: 560px; }
+.modal-box-ipdiag     { width: 560px; min-width: 560px; }
+.modal-box-mw         { width: 620px; min-width: 620px; }
+.modal-box-trusted-ips{ width: 600px; min-width: 600px; }
+.modal-box-rm-groups  { width: 460px; min-width: 460px; overflow: hidden; display: flex; flex-direction: column; }
+.modal-box-rm-edit    { width: 440px; min-width: 440px; overflow: hidden; display: flex; flex-direction: column; }
+.modal-box-settings   { width: 680px; min-width: 680px; height: 88vh; max-height: 95vh; min-height: 420px; display: flex; flex-direction: column; }
 
 
 .modal-inner { display: flex; flex: 1; overflow: hidden; min-height: 380px; }
@@ -779,7 +800,7 @@ label { display: block; font-size: 12px; font-weight: 600; color: var(--muted); 
     .modal-box { max-width: 100% !important; width: 100%; border-radius: 18px 18px 0 0; max-height: 92vh; }
 
     #settingsModal { align-items: stretch !important; }
-    #settingsModal .modal-box { border-radius: 0 !important; max-height: 100% !important; height: 100% !important; overflow-x: hidden; }
+    #settingsModal .modal-box { border-radius: 0 !important; max-height: 100% !important; height: 100% !important; overflow-x: hidden; resize: none !important; }
     #settingsModal .modal-inner { flex: 1; overflow: hidden; min-height: unset; }
     #settingsModal .modal-sidebar { display: none !important; }
     #settingsModal #settingsPanelWrapper { display: flex; flex-direction: column; flex: 1; overflow: hidden; }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -274,14 +274,14 @@ select.input-field:disabled { opacity: 0.6; cursor: not-allowed; }
     resize: horizontal;
     border-bottom-right-radius: 4px;
 }
-.modal-box-route      { width: 560px; min-width: 560px; }
-.modal-box-tls        { width: 560px; min-width: 560px; }
-.modal-box-ipdiag     { width: 560px; min-width: 560px; }
-.modal-box-mw         { width: 620px; min-width: 620px; }
-.modal-box-trusted-ips{ width: 600px; min-width: 600px; }
-.modal-box-rm-groups  { width: 460px; min-width: 460px; overflow: hidden; display: flex; flex-direction: column; }
-.modal-box-rm-edit    { width: 440px; min-width: 440px; overflow: hidden; display: flex; flex-direction: column; }
-.modal-box-settings   { width: 680px; min-width: 680px; height: 88vh; max-height: 95vh; min-height: 420px; display: flex; flex-direction: column; }
+.modal-box-route      { width: 560px; min-width: min(560px, 95vw); }
+.modal-box-tls        { width: 560px; min-width: min(560px, 95vw); }
+.modal-box-ipdiag     { width: 560px; min-width: min(560px, 95vw); }
+.modal-box-mw         { width: 620px; min-width: min(620px, 95vw); }
+.modal-box-trusted-ips{ width: 600px; min-width: min(600px, 95vw); }
+.modal-box-rm-groups  { width: 460px; min-width: min(460px, 95vw); overflow: hidden; display: flex; flex-direction: column; }
+.modal-box-rm-edit    { width: 440px; min-width: min(440px, 95vw); overflow: hidden; display: flex; flex-direction: column; }
+.modal-box-settings   { width: 680px; min-width: min(680px, 95vw); height: 88vh; max-height: 88vh; display: flex; flex-direction: column; }
 
 
 .modal-inner { display: flex; flex: 1; overflow: hidden; min-height: 380px; }

--- a/templates/modals/ip_diagnostic_modal.html
+++ b/templates/modals/ip_diagnostic_modal.html
@@ -1,5 +1,5 @@
 <div id="ipDiagModal" class="modal-overlay" style="display:none" onclick="_onBackdropClick(event, closeIpDiagModal)">
-    <div class="modal-box" style="max-width:560px">
+    <div class="modal-box modal-box-ipdiag">
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border)">
             <div class="flex items-center gap-2">
                 <i class="ph-bold ph-network" style="color:var(--blue)"></i>

--- a/templates/modals/mw_modal.html
+++ b/templates/modals/mw_modal.html
@@ -1,5 +1,5 @@
 <div id="mwModal" class="modal-overlay" style="display:none">
-    <div class="modal-box" style="max-width:620px">
+    <div class="modal-box modal-box-mw">
         <form id="mwForm" action="{{ url_for('save_middleware') }}" method="POST" onsubmit="saveMwAjax(event)">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="hidden" name="isMwEdit" id="isMwEdit" value="false">

--- a/templates/modals/route_modal.html
+++ b/templates/modals/route_modal.html
@@ -1,5 +1,5 @@
 <div id="appModal" class="modal-overlay" style="display:none">
-    <div class="modal-box">
+    <div class="modal-box modal-box-route">
         <form id="routeForm" action="{{ url_for('save_entry') }}" method="POST" onsubmit="saveRouteAjax(event)">
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
             <input type="hidden" name="isEdit" id="isEdit" value="false">

--- a/templates/modals/settings_modal.html
+++ b/templates/modals/settings_modal.html
@@ -1,5 +1,5 @@
 <div id="settingsModal" class="modal-overlay" style="display:none" onclick="_onBackdropClick(event,closeSettingsModal)">
-    <div class="modal-box" style="max-width:680px;height:88vh;max-height:88vh;overflow:hidden;display:flex;flex-direction:column;">
+    <div class="modal-box modal-box-settings">
 
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border);flex-shrink:0;">
             <div class="flex items-center gap-2">

--- a/templates/modals/tls_options_modal.html
+++ b/templates/modals/tls_options_modal.html
@@ -1,5 +1,5 @@
 <div id="tlsOptionsModal" class="modal-overlay" style="display:none">
-    <div class="modal-box">
+    <div class="modal-box modal-box-tls">
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border)">
             <div class="flex items-center gap-2">
                 <i class="ph-bold ph-lock-key" style="color:var(--blue)"></i>

--- a/templates/modals/trusted_ips_modal.html
+++ b/templates/modals/trusted_ips_modal.html
@@ -1,5 +1,5 @@
 <div id="trustedIpsModal" class="modal-overlay" style="display:none;z-index:9997" onclick="_onBackdropClick(event, closeTrustedIpsModal)">
-    <div class="modal-box" style="max-width:600px">
+    <div class="modal-box modal-box-trusted-ips">
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border)">
             <div class="flex items-center gap-2">
                 <i class="ph-bold ph-shield-check" style="color:var(--green)"></i>

--- a/templates/tabs/tab_dashboard.html
+++ b/templates/tabs/tab_dashboard.html
@@ -33,7 +33,7 @@
 </div>
 
 <div id="rmGroupsModal" class="modal-overlay" style="display:none" onclick="_onBackdropClick(event,rmCloseGroupsModal)">
-    <div class="modal-box" style="max-width:460px;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-box modal-box-rm-groups">
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border);flex-shrink:0">
             <div class="flex items-center gap-2">
                 <i class="ph-fill ph-tag" style="color:var(--blue);font-size:18px"></i>
@@ -57,7 +57,7 @@
 </div>
 
 <div id="rmEditModal" class="modal-overlay" style="display:none" onclick="_onBackdropClick(event,rmCloseEditModal)">
-    <div class="modal-box" style="max-width:440px;overflow:hidden;display:flex;flex-direction:column">
+    <div class="modal-box modal-box-rm-edit">
         <div class="flex items-center justify-between px-5 py-4" style="border-bottom:1px solid var(--border);flex-shrink:0">
             <div class="flex items-center gap-2">
                 <i class="ph-fill ph-pencil-simple" style="color:var(--blue);font-size:18px"></i>


### PR DESCRIPTION
## Summary
- Every modal (settings, route, TLS profile, middleware, IP diagnostic, trusted IPs, route groups, edit route) can now be dragged wider via native CSS `resize: horizontal`, instead of being locked to a fixed max-width.
- Each modal keeps its exact original default width as a floor (`min-width`), so nothing shifts in size until the user drags the handle - the settings modal still opens at 680px.
- The bottom-right corner of resizable modals is flattened slightly (`border-bottom-right-radius: 4px`) so the native resize grip nests into the corner instead of overhanging the modal's rounded border.
- Moved the per-modal width values from inline `style` attributes into `static/css/app.css`, per the CSS/inline-style convention in CONTRIBUTING.md.

## Test plan
- [ ] Open each modal (Settings, Route, TLS Profile, Middleware, Client IP Diagnostic, Trusted IPs Helper, Route Groups, Edit Route) and confirm it renders at its usual size.
- [ ] Drag the bottom-right corner of each modal and confirm it resizes horizontally and the grip sits inside the rounded corner.
- [ ] Confirm mobile (<=640px) layout is unaffected - modals still go full-width/full-screen.